### PR TITLE
fix(docker): cap qbittorrent RAM, move plex transcode off tmpfs

### DIFF
--- a/docker/downloads/compose.yml
+++ b/docker/downloads/compose.yml
@@ -8,6 +8,8 @@ services:
     container_name: qbittorrent
     security_opt:
       - no-new-privileges:true
+    mem_limit: 1g
+    memswap_limit: 1g
     networks:
       - proxy
     environment:

--- a/docker/plex/compose.yml
+++ b/docker/plex/compose.yml
@@ -17,9 +17,9 @@ services:
       - PLEX_CLAIM=${PLEX_CLAIM}
     volumes:
       - plex-data:/config
+      - plex-transcode:/transcode
       - /mnt/data/media:/data/media:rw
       - /mnt/music:/data/music:rw
-      - /dev/shm:/transcode # ram transcode
     labels:
       - traefik.enable=true
       - traefik.http.routers.plex.rule=Host(`plex.local.elmurphy.com`)
@@ -102,6 +102,8 @@ services:
 volumes:
   plex-data:
     name: plex-data
+  plex-transcode:
+    name: plex-transcode
   tautulli-data:
     name: tautulli-data
   overseerr-data:


### PR DESCRIPTION
## Summary

- Docker-host VM is RAM-constrained (9.7G total, ~2G swap consistently used). 30-day audit via Beszel showed qbittorrent peaks at 4.7G and `/dev/shm` (Plex transcode) is unbounded at 4.9G — they contend for the same pool.
- **qbittorrent**: hard cap at 1G (`mem_limit` + `memswap_limit` equal disables container swap).
- **plex**: replace `/dev/shm:/transcode` with named volume `plex-transcode` on the VM's local FS. Hardware transcode (`/dev/dri`) is on, so iGPU does the work; scratch I/O is not the bottleneck.

## Test plan

- [ ] `cd docker/downloads && docker compose up -d qbittorrent` — verify container starts, WebUI reachable
- [ ] `docker stats qbittorrent --no-stream` shows `LIMIT 1GiB`
- [ ] `cd docker/plex && docker compose up -d plex` — verify container starts
- [ ] Confirm Plex setting: Settings → Transcoder → Transcoder temporary directory = `/transcode`
- [ ] Trigger a transcode (force quality change), confirm files appear under `/var/lib/docker/volumes/plex-transcode/_data` and host RAM stays stable
- [ ] After ~24h, recheck `free -h` on docker-host — swap usage should drop