### PR TITLE
feat(ansible): swap_mode dispatcher with zram on ai-dev

### DIFF
--- a/ansible/group_vars/ai-dev.yaml
+++ b/ansible/group_vars/ai-dev.yaml
@@ -1,3 +1,8 @@
 ---
 username: michael
 ssh_public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8UxcTkHym30wEg6jekF"
+
+swap_mode: zram
+swap_swappiness: 100
+zram_size: ram
+zram_compression: zstd

--- a/ansible/group_vars/docker.yaml
+++ b/ansible/group_vars/docker.yaml
@@ -2,3 +2,7 @@
 username: mm
 ssh_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8UxcTkHym30wEg6jekF
 docker_users: "{{ username }}"
+
+swap_mode: file
+swap_size_gb: 4
+swap_swappiness: 60

--- a/ansible/roles/common/defaults/main.yaml
+++ b/ansible/roles/common/defaults/main.yaml
@@ -1,2 +1,9 @@
 ---
+# Swap mode: file | zram | none
+swap_mode: file
 swap_size_gb: 4
+swap_swappiness: 60
+
+# zram-generator options (used when swap_mode == zram)
+zram_size: ram
+zram_compression: zstd

--- a/ansible/roles/common/tasks/swap-file.yaml
+++ b/ansible/roles/common/tasks/swap-file.yaml
@@ -1,0 +1,99 @@
+---
+# Disable zram if previously configured (mode flip cleanup)
+- name: check for zram-generator config
+  ansible.builtin.stat:
+    path: /etc/systemd/zram-generator.conf
+  register: zram_conf
+
+- name: stop and disable zram service
+  ansible.builtin.systemd:
+    name: systemd-zram-setup@zram0.service
+    state: stopped
+    enabled: false
+  when: zram_conf.stat.exists
+  failed_when: false
+
+- name: remove zram-generator config
+  ansible.builtin.file:
+    path: /etc/systemd/zram-generator.conf
+    state: absent
+  when: zram_conf.stat.exists
+
+# Build / rebuild file swap
+- name: stat target swapfile
+  ansible.builtin.stat:
+    path: /swapfile
+  register: target_swap
+
+- name: detect root filesystem type
+  ansible.builtin.set_fact:
+    root_fstype: "{{ (ansible_mounts | selectattr('mount', 'eq', '/') | list | first).fstype }}"
+
+- name: list active swap devices
+  ansible.builtin.command:
+    cmd: swapon --show=NAME --noheadings
+  register: active_swaps
+  changed_when: false
+
+- name: compute swap state
+  ansible.builtin.set_fact:
+    swap_rebuild: "{{ (not target_swap.stat.exists) or (target_swap.stat.size | int != (swap_size_gb | int) * 1024 * 1024 * 1024) or ('/swapfile' not in active_swaps.stdout_lines) }}"
+
+- name: disable existing swap devices
+  ansible.builtin.command:
+    cmd: "swapoff {{ item }}"
+  loop: "{{ active_swaps.stdout_lines | default([]) }}"
+  when: swap_rebuild and active_swaps.stdout_lines | default([]) | length > 0
+
+- name: remove stale fstab swap entries
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    regexp: '^\S+\s+\S+\s+swap\s'
+    state: absent
+  when: swap_rebuild
+
+- name: remove old swapfile paths
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /swap.img
+    - /swap/swapfile
+    - /swapfile
+  when: swap_rebuild
+
+- name: allocate swapfile (btrfs)
+  ansible.builtin.command:
+    cmd: "btrfs filesystem mkswapfile --size {{ swap_size_gb }}g /swapfile"
+  when: swap_rebuild and root_fstype == 'btrfs'
+
+- name: allocate swapfile (generic)
+  ansible.builtin.command:
+    cmd: "fallocate -l {{ swap_size_gb }}G /swapfile"
+  when: swap_rebuild and root_fstype != 'btrfs'
+
+- name: secure swapfile perms
+  ansible.builtin.file:
+    path: /swapfile
+    owner: root
+    group: root
+    mode: "0600"
+  when: swap_rebuild
+
+- name: format swapfile (generic)
+  ansible.builtin.command:
+    cmd: mkswap /swapfile
+  when: swap_rebuild and root_fstype != 'btrfs'
+
+- name: enable swapfile
+  ansible.builtin.command:
+    cmd: swapon /swapfile
+  when: swap_rebuild
+
+- name: persist swapfile in fstab
+  ansible.posix.mount:
+    path: none
+    src: /swapfile
+    fstype: swap
+    opts: sw
+    state: present

--- a/ansible/roles/common/tasks/swap-none.yaml
+++ b/ansible/roles/common/tasks/swap-none.yaml
@@ -1,0 +1,39 @@
+---
+- name: list active swap devices
+  ansible.builtin.command:
+    cmd: swapon --show=NAME --noheadings
+  register: active_swaps
+  changed_when: false
+
+- name: swapoff everything
+  ansible.builtin.command:
+    cmd: "swapoff {{ item }}"
+  loop: "{{ active_swaps.stdout_lines | default([]) }}"
+  when: active_swaps.stdout_lines | default([]) | length > 0
+
+- name: remove swap fstab entries
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    regexp: '^\S+\s+\S+\s+swap\s'
+    state: absent
+
+- name: delete stale swapfiles
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /swap.img
+    - /swap/swapfile
+    - /swapfile
+
+- name: stop and disable zram service
+  ansible.builtin.systemd:
+    name: systemd-zram-setup@zram0.service
+    state: stopped
+    enabled: false
+  failed_when: false
+
+- name: remove zram-generator config
+  ansible.builtin.file:
+    path: /etc/systemd/zram-generator.conf
+    state: absent

--- a/ansible/roles/common/tasks/swap-zram.yaml
+++ b/ansible/roles/common/tasks/swap-zram.yaml
@@ -1,0 +1,74 @@
+---
+# Remove file swap if previously configured (mode flip cleanup)
+- name: list active swap devices
+  ansible.builtin.command:
+    cmd: swapon --show=NAME --noheadings
+  register: active_swaps
+  changed_when: false
+
+- name: swapoff non-zram devices
+  ansible.builtin.command:
+    cmd: "swapoff {{ item }}"
+  loop: "{{ active_swaps.stdout_lines | default([]) | reject('match', '^/dev/zram') | list }}"
+  when: (active_swaps.stdout_lines | default([]) | reject('match', '^/dev/zram') | list) | length > 0
+
+- name: remove swapfile fstab entries
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    regexp: '^\S+\s+\S+\s+swap\s'
+    state: absent
+
+- name: delete stale swapfiles
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /swap.img
+    - /swap/swapfile
+    - /swapfile
+
+# Install zram-generator (package name differs per distro)
+- name: install zram-generator (Arch)
+  community.general.pacman:
+    name: zram-generator
+    state: present
+  when: ansible_os_family == 'Archlinux'
+
+- name: install systemd-zram-generator (Debian/Ubuntu)
+  ansible.builtin.apt:
+    name: systemd-zram-generator
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: ansible_os_family == 'Debian'
+
+# Configure and (re)start zram
+- name: write zram-generator config
+  ansible.builtin.copy:
+    dest: /etc/systemd/zram-generator.conf
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [zram0]
+      zram-size = {{ zram_size }}
+      compression-algorithm = {{ zram_compression }}
+  register: zram_conf
+
+- name: daemon-reload after config change
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: zram_conf.changed
+
+- name: stop zram device for resize
+  ansible.builtin.systemd:
+    name: systemd-zram-setup@zram0.service
+    state: stopped
+  when: zram_conf.changed
+  failed_when: false
+
+- name: start zram swap
+  ansible.builtin.systemd:
+    name: systemd-zram-setup@zram0.service
+    state: started
+    enabled: true

--- a/ansible/roles/common/tasks/swap.yaml
+++ b/ansible/roles/common/tasks/swap.yaml
@@ -1,86 +1,25 @@
 ---
-- name: stat target swapfile
-  ansible.builtin.stat:
-    path: /swapfile
-  register: target_swap
+- name: validate swap_mode
+  ansible.builtin.assert:
+    that: swap_mode in ['file', 'zram', 'none']
+    fail_msg: "swap_mode must be one of: file, zram, none (got: {{ swap_mode }})"
 
-- name: detect root filesystem type
-  ansible.builtin.set_fact:
-    root_fstype: "{{ (ansible_mounts | selectattr('mount', 'eq', '/') | list | first).fstype }}"
+- name: configure file swap
+  ansible.builtin.include_tasks: swap-file.yaml
+  when: swap_mode == 'file'
 
-- name: list active swap devices
-  ansible.builtin.command:
-    cmd: swapon --show=NAME --noheadings
-  register: active_swaps
-  changed_when: false
+- name: configure zram swap
+  ansible.builtin.include_tasks: swap-zram.yaml
+  when: swap_mode == 'zram'
 
-- name: compute swap state
-  ansible.builtin.set_fact:
-    swap_rebuild: "{{ (not target_swap.stat.exists) or (target_swap.stat.size | int != (swap_size_gb | int) * 1024 * 1024 * 1024) or ('/swapfile' not in active_swaps.stdout_lines) }}"
-
-- name: disable existing swap devices
-  ansible.builtin.command:
-    cmd: "swapoff {{ item }}"
-  loop: "{{ active_swaps.stdout_lines | default([]) }}"
-  when: swap_rebuild and active_swaps.stdout_lines | default([]) | length > 0
-
-- name: remove stale fstab swap entries
-  ansible.builtin.lineinfile:
-    path: /etc/fstab
-    regexp: '^\S+\s+\S+\s+swap\s'
-    state: absent
-  when: swap_rebuild
-
-- name: remove old swapfile paths
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /swap.img
-    - /swap/swapfile
-    - /swapfile
-  when: swap_rebuild
-
-- name: allocate swapfile (btrfs)
-  ansible.builtin.command:
-    cmd: "btrfs filesystem mkswapfile --size {{ swap_size_gb }}g /swapfile"
-  when: swap_rebuild and root_fstype == 'btrfs'
-
-- name: allocate swapfile (generic)
-  ansible.builtin.command:
-    cmd: "fallocate -l {{ swap_size_gb }}G /swapfile"
-  when: swap_rebuild and root_fstype != 'btrfs'
-
-- name: secure swapfile perms
-  ansible.builtin.file:
-    path: /swapfile
-    owner: root
-    group: root
-    mode: "0600"
-  when: swap_rebuild
-
-- name: format swapfile (generic)
-  ansible.builtin.command:
-    cmd: mkswap /swapfile
-  when: swap_rebuild and root_fstype != 'btrfs'
-
-- name: enable swapfile
-  ansible.builtin.command:
-    cmd: swapon /swapfile
-  when: swap_rebuild
-
-- name: persist swapfile in fstab
-  ansible.posix.mount:
-    path: none
-    src: /swapfile
-    fstype: swap
-    opts: sw
-    state: present
+- name: disable all swap
+  ansible.builtin.include_tasks: swap-none.yaml
+  when: swap_mode == 'none'
 
 - name: tune swappiness
   ansible.posix.sysctl:
     name: vm.swappiness
-    value: "10"
+    value: "{{ swap_swappiness | string }}"
     state: present
     sysctl_set: true
     reload: true


### PR DESCRIPTION
## Summary

- Refactor swap role into a dispatcher (`swap_mode: file|zram|none`) that includes mode-specific task files.
- ai-dev VMs (3 GB RAM, host now 32 GB after DIMM failure) switch to `zram-generator` — compressed RAM swap, no virtual-disk thrash. Swappiness 100.
- docker-host keeps 4 GB file swap; swappiness bumped 10 → 60 so kernel actually uses swap before OOM.
- Each mode cleans up the other's artifacts on apply, so mode flips are safe.

## Why

ai-dev had 4 GB swap on a 3 GB VM → swap > RAM, all on virtual disk = double-swap latency (guest swaps to virtio, host then swaps too). With host RAM halved, can't simply bump VM memory. zram gives ~2–3× effective RAM at zero host cost.

## Test plan

- [x] `ansible-playbook --syntax-check run.yaml` — clean
- [x] Dry-run on ai-dev (`--check --diff`) — expected service-not-found in check mode only (generator not installed)
- [x] Apply to ai-dev — both hosts converged, `/dev/zram0` active 3.8 G, swappiness 100, service active
- [x] Apply to docker-host — `/swapfile` retained, swappiness 60, no zram artifacts
- [x] Verify mode-flip cleanup paths (swap-file cleans zram; swap-zram cleans /swapfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)