### PR TITLE
feat(network): add WPA3 MGMT SSID, align WLAN resource/PSK naming

### DIFF
--- a/terraform/network/main.tf
+++ b/terraform/network/main.tf
@@ -1,6 +1,6 @@
-# Required 1Password items (auth inherited via direnv, like terraform/unifi/):
-#   unifi_controller - controller Limited Admin (local-only) username/password
-#   unifi_wlan_psks  - section "WLAN" with PSK fields: dflt, kids, guest
+# Required 1Password items (auth inherited via direnv):
+#   unifi_controller - Limited Admin (local-only) username/password
+#   unifi_wlan_psks  - section "WLAN", PSK fields: dflt, kds, gst, mgmt (mgmt: 24+ char random)
 data "onepassword_item" "unifi_controller" {
   vault = "5v7zjyz2kanfxgsui2jx735vum"
   title = "unifi_controller"

--- a/terraform/network/unifi.tf
+++ b/terraform/network/unifi.tf
@@ -1,10 +1,16 @@
-# WLANs require an AP group + user group id; look up the controller defaults by name.
+# WLANs require an AP group + user group id; look these up from the controller defaults.
 data "unifi_ap_group" "default" {
   name = var.unifi_ap_group_name
 }
 
 data "unifi_client_qos_rate" "default" {
   name = var.unifi_user_group_name
+}
+
+# Native/untagged LAN (VLAN 1 = MGMT). MGMT SSID attaches here so clients land untagged
+# on VLAN 1 alongside the router, IPMI/BMC and controller. No RouterOS change needed.
+data "unifi_network" "mgmt" {
+  name = var.unifi_default_network_name
 }
 
 # third_party_gateway = the RB5009 owns L3/DHCP; the controller only tags the VLAN.
@@ -18,7 +24,7 @@ resource "unifi_network" "vlan" {
 }
 
 # DFLT — WPA3 transition (Sonos/AppleTV share this subnet; mDNS stays native).
-resource "unifi_wlan" "main" {
+resource "unifi_wlan" "dflt" {
   name            = "madviLANy"
   security        = "wpapsk"
   passphrase      = local.psk["dflt"].value
@@ -31,10 +37,10 @@ resource "unifi_wlan" "main" {
 }
 
 # KDS — WPA3-only.
-resource "unifi_wlan" "kids" {
+resource "unifi_wlan" "kds" {
   name            = "madviLANy-kds"
   security        = "wpapsk"
-  passphrase      = local.psk["kids"].value
+  passphrase      = local.psk["kds"].value
   wpa3_support    = true
   wpa3_transition = false
   pmf_mode        = "required"
@@ -44,10 +50,10 @@ resource "unifi_wlan" "kids" {
 }
 
 # GST — WPA3 transition + L2 isolation.
-resource "unifi_wlan" "guest" {
+resource "unifi_wlan" "gst" {
   name            = "madviLANy-gst"
   security        = "wpapsk"
-  passphrase      = local.psk["guest"].value
+  passphrase      = local.psk["gst"].value
   wpa3_support    = true
   wpa3_transition = true
   pmf_mode        = "optional"
@@ -58,11 +64,25 @@ resource "unifi_wlan" "guest" {
   user_group_id   = data.unifi_client_qos_rate.default.id
 }
 
-# Fallback if a legacy Sonos won't join the WPA3 SSID: same DFLT network_id keeps
-# mDNS native. Uncomment + add a `sonos` PSK field.
-#
+# MGMT — WPA3-only, hidden admin SSID on native VLAN 1 (router, IPMI/BMC, controller).
+# No l2_isolation: those are peer hosts on VLAN 1, isolation would block IPMI + controller.
+# wpa3_transition=false: no WPA2 downgrade path; security rests on WPA3-SAE + long PSK.
+resource "unifi_wlan" "mgmt" {
+  name            = "madviLANy-mgmt"
+  security        = "wpapsk"
+  passphrase      = local.psk["mgmt"].value
+  wpa3_support    = true
+  wpa3_transition = false
+  pmf_mode        = "required"
+  hide_ssid       = true
+  network_id      = data.unifi_network.mgmt.id
+  ap_group_ids    = [data.unifi_ap_group.default.id]
+  user_group_id   = data.unifi_client_qos_rate.default.id
+}
+
+# Fallback if a legacy Sonos won't join WPA3: uncomment, add a `sonos` PSK field (DFLT keeps mDNS native).
 # resource "unifi_wlan" "sonos" {
-#   name            = "Skynet-Sonos"
+#   name            = "madviLANy-sonos"
 #   security        = "wpapsk"
 #   passphrase      = local.psk["sonos"].value
 #   wpa3_support    = false

--- a/terraform/network/variables.tf
+++ b/terraform/network/variables.tf
@@ -4,8 +4,7 @@ variable "unifi_api_url" {
   default     = "https://10.77.1.10:8443"
 }
 
-# Controller defaults the SSIDs attach to. Override if your controller labels them
-# differently (Settings -> WiFi -> AP Groups, and the user group / QoS rate name).
+# Controller defaults the SSIDs attach to; override if labelled differently (Settings -> WiFi).
 variable "unifi_ap_group_name" {
   type    = string
   default = "Default"
@@ -16,12 +15,18 @@ variable "unifi_user_group_name" {
   default = "Default"
 }
 
-# Wireless VLANs only (MGMT/SRV/DMZ are wired — see the routeros role). `subnet` is
-# the router-side gateway CIDR; required by the schema but not served by the controller.
+# Native LAN (VLAN 1) the MGMT SSID attaches to; a second untagged network is rejected. Override if renamed.
+variable "unifi_default_network_name" {
+  type    = string
+  default = "Default"
+}
+
+# Wireless VLANs only (MGMT/SRV/DMZ are wired — see the routeros role). `subnet` (gateway
+# CIDR on the RB5009) is required by the schema but not served by the controller.
 variable "wireless_vlans" {
   type = map(object({
     vlan   = number
-    subnet = string # gateway CIDR on the RB5009
+    subnet = string
   }))
   default = {
     dflt = { vlan = 30, subnet = "10.77.30.1/24" }


### PR DESCRIPTION
## MGMT SSID
Adds a hidden, **WPA3-only** (`wpa3_transition = false`) management SSID **`madviLANy-mgmt`** on the native **VLAN 1**, attached to the controller's default network. Lands clients alongside the router (`10.77.1.1`), IPMI/BMC (`.99`) and the UniFi controller (`.10`) — all reachable over WiFi.

- `pmf_mode = required`, `hide_ssid = true`
- **No `l2_isolation`** — those are peer hosts on VLAN 1; isolation would permit only the gateway and block IPMI + controller. Security rests on WPA3-SAE + a long PSK, not topology.
- No RouterOS change: the SSID rides untagged on the AP trunk (ether4) → native VLAN 1.

## Naming consistency
Align WLAN resource labels + PSK keys to the rolled-out VLAN names (VLANs unchanged):

| | old | new |
|---|---|---|
| resource | `unifi_wlan.main` | `unifi_wlan.dflt` |
| resource | `unifi_wlan.kids` | `unifi_wlan.kds` |
| resource | `unifi_wlan.guest` | `unifi_wlan.gst` |
| psk key | `local.psk["kids"]` | `local.psk["kds"]` |
| psk key | `local.psk["guest"]` | `local.psk["gst"]` |

Flagship `madviLANy` (dflt) deliberately kept unsuffixed; commented Sonos fallback renamed `Skynet-Sonos` → `madviLANy-sonos`.

> [!IMPORTANT]
> Before `terraform apply`:
> 1. Add a `mgmt` field (24+ char random) to the `unifi_wlan_psks` 1Password item; rename fields `kids`→`kds`, `guest`→`gst`.
> 2. `terraform state mv` the renamed `unifi_wlan` resources (`main`→`dflt`, `kids`→`kds`, `guest`→`gst`) so they aren't destroyed/recreated.
> 3. `terraform plan` — confirm no destroy/recreate; only `madviLANy-mgmt` should be a create.

`terraform fmt -check` + `validate` pass.

> [!NOTE]
> Stacked on `fix/vlan-port-map-and-hardening` (PR #1447). Merge after #1447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)