### PR TITLE
fix(network): make router hardening steady state

### DIFF
--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -27,12 +27,12 @@ routeros_vlan1_untagged_ports:
 
 # MGMT = existing flat network (kept as-is, referenced by the firewall).
 routeros_mgmt_subnet: 10.77.1.0/24
-# Sources allowed to reach the encrypted management services (ssh/winbox/api-ssl/www-ssl).
-# Defaults to MGMT; add Tailscale CGNAT (100.64.0.0/10) here if you manage off-LAN.
-routeros_mgmt_admin_sources: 10.77.1.0/24
 routeros_admin_station: 10.77.1.241 # this Mac (MGMT) — see note: DHCP, reserve a lease before default-drop
 routeros_ipmi_host: 10.77.1.99 # Proxmox IPMI/BMC
 routeros_unifi_ctrl: 10.77.1.10
+# Sources allowed to reach encrypted management services (ssh/winbox/api-ssl/www-ssl).
+# Add a comma-separated subnet such as 100.64.0.0/10 only if off-LAN management is required.
+routeros_mgmt_admin_sources: "{{ routeros_admin_station }}"
 
 # Tagged on the trunk bridge; MGMT/VLAN 1 is the untagged net.
 routeros_vlans:
@@ -52,7 +52,7 @@ routeros_dmz:
 routeros_default_dns: 10.77.1.1
 routeros_kids_dns: 1.1.1.3 # OPEN ITEM: Cloudflare Families / NextDNS / AdGuard
 
-# Disruptive / lockout-risk steps — gated by var + tag, skipped on a normal run. See README.
-routeros_enable_dmz: false # de-bridges ether2 + renumbers ai-dev VMs into 10.77.99.0/24
-routeros_enable_vlan_filtering: false
-routeros_enable_default_drop: false
+# Steady-state hardening. These were disruptive during rollout, but are now desired state.
+routeros_enable_dmz: true
+routeros_enable_vlan_filtering: true
+routeros_enable_default_drop: true

--- a/ansible/group_vars/unifi.yaml
+++ b/ansible/group_vars/unifi.yaml
@@ -6,13 +6,17 @@ ssh_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8Ux
 swap_mode: none
 swap_swappiness: 10
 
-# Inbound ports scoped to the flat LAN; tighten `from` to mgmt VLAN once VLANs exist.
+unifi_admin_source: 10.77.1.241
+unifi_ap_source: 10.77.1.0/24
+
+# Admin ports are pinned to the admin station; AP-facing ports stay on the MGMT LAN
+# until the AP has a reserved address/subnet that can be narrower.
 # MongoDB (27117) is deliberately absent: it binds localhost only, never expose it.
-# SSH is LAN-scoped because the controller has no Tailscale; its from_ip differs from
+# SSH is explicitly allowed because the controller has no Tailscale; its from_ip differs from
 # the firewall role's deleted bare 22/tcp rule so it survives default-deny.
 firewall_allow_ports:
-  - { port: "22", proto: tcp, from: "10.77.1.0/24" } # ssh / ansible (LAN only)
-  - { port: "8080", proto: tcp, from: "10.77.1.0/24" } # device inform / adoption
-  - { port: "8443", proto: tcp, from: "10.77.1.0/24" } # controller GUI (admin)
-  - { port: "3478", proto: udp, from: "10.77.1.0/24" } # STUN
-  - { port: "10001", proto: udp, from: "10.77.1.0/24" } # AP discovery
+  - { port: "22", proto: tcp, from: "{{ unifi_admin_source }}" } # ssh / ansible
+  - { port: "8443", proto: tcp, from: "{{ unifi_admin_source }}" } # controller GUI
+  - { port: "8080", proto: tcp, from: "{{ unifi_ap_source }}" } # device inform / adoption
+  - { port: "3478", proto: udp, from: "{{ unifi_ap_source }}" } # STUN
+  - { port: "10001", proto: udp, from: "{{ unifi_ap_source }}" } # AP discovery

--- a/ansible/roles/routeros/README.md
+++ b/ansible/roles/routeros/README.md
@@ -3,9 +3,10 @@
 Configures the Mikrotik RB5009 (RouterOS v7) over the API using
 `community.routeros.api_modify`. All data lives in `group_vars/routeros.yaml`.
 
-Every task is **non-destructive** (`handle_absent_entries: ignore`): it reconciles
-only the entries declared here and never removes the router's existing WAN/base rules.
-Managed entries carry a `managed: routeros role` comment.
+The role reconciles managed entries and leaves unrelated WAN/base rules alone.
+Managed entries carry a `managed: routeros role` comment. The DMZ de-bridge is
+the only managed removal, because physical isolation requires `routeros_dmz_port`
+to be absent from the production bridge.
 
 ## Prerequisites
 
@@ -17,32 +18,23 @@ Managed entries carry a `managed: routeros role` comment.
    Put `routeros_api_user` / `routeros_api_password` in the vault (`just edit`).
 2. Confirm the OPEN ITEMS in `group_vars/routeros.yaml` (interface names, bridge
    name, admin/IPMI IPs, KDS DNS) against the live router.
-3. **Console/serial access ready** before the two gated steps below.
+3. Keep a console/serial fallback available before changing port maps or VLAN
+   membership.
 
-## Lockout-safe rollout
+## Steady State
 
-`just routeros` runs the safe steps (VLAN/DHCP/DMZ scaffolding, firewall *allows*,
-NAT) but **skips** the two dangerous flips, which are double-gated (a var
-*and* a `never` tag):
+`just routeros` applies the full desired state:
 
 ```sh
-# 1. Safe scaffold — VLANs, DHCP, address-lists, allow rules, NAT
-just routeros          # == ansible-playbook ... --limit routeros
-
-# 2. Verify the bridge VLAN table, then enable filtering (have console ready):
-cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass \
-  --limit routeros --tags vlan-filtering -e routeros_enable_vlan_filtering=true
-
-# 3. Verify all allows are present/ordered (`/ip firewall filter print`), THEN:
-cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass \
-  --limit routeros --tags default-drop -e routeros_enable_default_drop=true
+just routeros
 ```
 
-## ⚠️ Caveat — validate against the live router
+The normal run now maintains:
 
-These tasks were authored from the plan and the `community.routeros` schema, not
-against your live RB5009. Before trusting them: dry-run, and after each apply inspect
-the result (`/interface bridge vlan print`, `/ip firewall filter print`,
-`/ip dhcp-server print`). RouterOS firewall **rule ordering** in particular is not
-fully controlled by `api_modify` when pre-existing rules are present — verify the
-managed allows sit above the default-drop.
+- VLAN filtering on the bridge.
+- DMZ physical isolation by removing the DMZ port from the production bridge.
+- Forward-chain default drop after the managed allow rules.
+- RouterOS management services restricted to `routeros_mgmt_admin_sources`.
+
+After changes to the firewall matrix or port map, inspect `/interface bridge vlan print`,
+`/interface bridge port print`, `/ip firewall filter print`, and `/ip dhcp-server print`.

--- a/ansible/roles/routeros/tasks/bridge.yaml
+++ b/ansible/roles/routeros/tasks/bridge.yaml
@@ -34,8 +34,7 @@
         pvid: 1
   loop: "{{ routeros_mgmt_untagged_ports }}"
 
-# LOCKOUT RISK: run only after VLAN table verified, with console access ready. Double-gated (var + tag).
-- name: Enable bridge VLAN filtering (LOCKOUT RISK)
+- name: Enable bridge VLAN filtering
   community.routeros.api_modify:
     path: interface bridge
     handle_absent_entries: ignore
@@ -43,4 +42,4 @@
       - name: "{{ routeros_bridge }}"
         vlan-filtering: true
   when: routeros_enable_vlan_filtering | bool
-  tags: [never, vlan-filtering]
+  tags: [vlan-filtering]

--- a/ansible/roles/routeros/tasks/firewall.yaml
+++ b/ansible/roles/routeros/tasks/firewall.yaml
@@ -119,6 +119,13 @@
         action: redirect
         to-ports: 53
         comment: "KDS DNS redirect (managed: routeros role)"
+      - chain: dstnat
+        src-address: "{{ (routeros_vlans | selectattr('name', 'eq', 'kds') | first).subnet }}"
+        protocol: tcp
+        dst-port: 53
+        action: redirect
+        to-ports: 53
+        comment: "KDS TCP DNS redirect (managed: routeros role)"
 
 - name: Masquerade all internal sources out the WAN
   community.routeros.api_modify:
@@ -130,8 +137,7 @@
         action: masquerade
         comment: "masquerade (managed: routeros role)"
 
-# LOCKOUT RISK: apply LAST, after allows are verified in order. Double-gated (var + tag).
-- name: Forward — default drop (LOCKOUT RISK if allows aren't in place/order)
+- name: Forward — default drop
   community.routeros.api_modify:
     path: ip firewall filter
     handle_absent_entries: ignore
@@ -140,4 +146,4 @@
         action: drop
         comment: "DEFAULT DROP (managed: routeros role)"
   when: routeros_enable_default_drop | bool
-  tags: [never, default-drop]
+  tags: [default-drop]

--- a/ansible/roles/routeros/tasks/main.yaml
+++ b/ansible/roles/routeros/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-# Lockout-safe ordering matters (see README); vlan-filtering and default-drop are var+tag gated.
+# Lockout-safe ordering matters: membership and allow rules are reconciled before hardening flips.
 - name: Harden the management plane (disable telnet/cleartext, pin services to MGMT)
   ansible.builtin.import_tasks: services.yaml
   tags: [services]
@@ -8,10 +8,10 @@
   ansible.builtin.import_tasks: vlans.yaml
   tags: [vlans]
 
-- name: DMZ physical interface (de-bridge + gateway; disruptive, gated)
+- name: DMZ physical interface (de-bridge + gateway)
   ansible.builtin.import_tasks: dmz.yaml
   when: routeros_enable_dmz | bool
-  tags: [never, dmz]
+  tags: [dmz]
 
 - name: DHCP servers, pools and networks
   ansible.builtin.import_tasks: dhcp.yaml

--- a/terraform/unifi/variables.tf
+++ b/terraform/unifi/variables.tf
@@ -7,5 +7,5 @@ variable "unifi_ssh_public_key" {
 variable "template_url" {
   type        = string
   description = "URL of the Debian 12 LXC template fetched to the `local` datastore. Verify the version is still published before apply (pveam available --section system)."
-  default     = "http://download.proxmox.com/images/system/debian-12-standard_12.12-1_amd64.tar.zst"
+  default     = "https://download.proxmox.com/images/system/debian-12-standard_12.12-1_amd64.tar.zst"
 }


### PR DESCRIPTION
## Summary
Stacked on #1447. Converts the remaining rollout-only hardening into maintained desired state now that the port map and DMZ fixes are codified.

## Changes
- Make DMZ de-bridge, bridge VLAN filtering, and forward-chain default-drop part of the normal RouterOS run.
- Scope RouterOS encrypted management services to the admin station instead of the full MGMT subnet.
- Redirect KDS TCP DNS/53 as well as UDP DNS/53 so filtered DNS is harder to bypass.
- Scope UniFi controller SSH/GUI to the admin station while leaving AP adoption/discovery ports on the MGMT LAN.
- Fetch the Debian LXC template over HTTPS.
- Update the RouterOS role README from rollout instructions to steady-state behavior.

## Validation
- `terraform -chdir=terraform/unifi fmt -check`
- `ansible-playbook run.yaml --syntax-check --vault-password-file .vaultpass` from `ansible/`
- `git diff --check`

`terraform -chdir=terraform/unifi validate` is currently blocked by local provider startup failures for cached `1password/onepassword` and `bpg/proxmox` providers before schema load; the changed HCL formatted cleanly.
