### PR TITLE
Harden Terraform VM lifecycle and secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ docs
 .envrc
 
 # terraform
-.terraform.lock.hcl
 .terraform
 terraform.tfstate
 terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ just edit                   # edit encrypted vault secrets
 ## Terraform
 
 Provisions VMs on Proxmox using the [telmate/proxmox](https://registry.terraform.io/providers/Telmate/proxmox) provider. Secrets sourced from 1Password via the `onepassword` provider.
+Run Terraform through the `just` recipes so local state and generated cloud-init files are created with a restrictive umask. Terraform state is secret-bearing because provider data includes Proxmox credentials, WLAN PSKs, and bootstrap auth material.
 
 | VM           | ID  | Spec                         | Purpose                 |
 | ------------ | --- | ---------------------------- | ----------------------- |

--- a/justfile
+++ b/justfile
@@ -4,30 +4,30 @@
 
 ## terraform
 init:
-  cd terraform && terraform init
+  umask 077; cd terraform && terraform init
 
 apply:
-  cd terraform && terraform apply
+  umask 077; cd terraform && terraform apply
 
 destroy:
-  cd terraform && terraform destroy
+  umask 077; cd terraform && terraform destroy
 
 # UniFi controller LXC lives in its own root (bpg provider; see terraform/unifi/versions.tf)
 unifi-init:
-  cd terraform/unifi && terraform init
+  umask 077; cd terraform/unifi && terraform init
 
 unifi-apply:
-  cd terraform/unifi && terraform apply
+  umask 077; cd terraform/unifi && terraform apply
 
 # UniFi network objects (VLAN-only networks + WLANs) via ubiquiti-community/unifi
 network-init:
-  cd terraform/network && terraform init
+  umask 077; cd terraform/network && terraform init
 
 network-plan:
-  cd terraform/network && terraform plan
+  umask 077; cd terraform/network && terraform plan
 
 network-apply:
-  cd terraform/network && terraform apply
+  umask 077; cd terraform/network && terraform apply
 
 ## ansible
 run HOST:

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/1password/onepassword" {
+  version     = "3.3.1"
+  constraints = "3.3.1"
+  hashes = [
+    "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
+    "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
+    "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
+    "zh:161bc55c466214a5d425ba85753d74ed5078212db965f726e6650d2e1524d633",
+    "zh:3de4a9f212e1046016a3ace8816e2cb15cfb7b9579161e468a08b9034d6a5f51",
+    "zh:730105346065ea3d2bd6acc6f5fe36f7b8a2b54c513d20a46bcd51d656e82bb4",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c29f6025d099bc8f1f96e7bb4cd66c5d07209b4141d2fd7720228cf20c9c8efd",
+    "zh:d8ea431d396986ca6baf033fa9aaccb73d6a9f9b7d42bea7af8dc73b9ef20297",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.9.0"
+  constraints = "2.9.0"
+  hashes = [
+    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
+    "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
+    "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
+    "zh:197c79015a10d1cce904a8ea722cbc750c42aeae2da53f44a6a0751d9fd1aa90",
+    "zh:29d0b03e5343a80677ebfeb2e2c31cbe4b1f65e736e53417454a4277fec2544c",
+    "zh:4896bfa6cf1d2fd562b47ef2e87f47862ae92a04f8ad5d764380f0c6653473b8",
+    "zh:531f8529cbca49f681883e57761a05a8398afaef6d1ab0d205d26bf12f4428e8",
+    "zh:6aaf5011d83161c86d2bfb80c0923ec934e578288758da2f37acb7aec129004b",
+    "zh:7430275253d3d3c40aa6179e0ec0d63212874dbbc06c5a51b9d07ec590f9756c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:be17dc611e95e26cdf6cad79dfccf1064f0e32032a2efeb939a9bbe7fb1cbfe9",
+    "zh:f0e3b0aa644202e1d79d2000dca91f6019425da71e9800fa23f27e51c034f195",
+    "zh:f62bae4519e4ead49182ddc8afe8cf61e2a4c3ba3973b0fbba967736a2696aa3",
+    "zh:fcafa360a5b0b96244f26f4e3a6d642b716a376557142c2442ff2fb12d11da18",
+  ]
+}
+
+provider "registry.terraform.io/telmate/proxmox" {
+  version     = "3.0.2-rc07"
+  constraints = "3.0.2-rc07"
+  hashes = [
+    "h1:0UpRJ8PFsu9lhD3p2KUdUNVsDPbjZLPR46wYRpt1dxc=",
+    "zh:2ee860cd0a368b3eaa53f4a9ea46f16dab8a97929e813ea6ef55183f8112c2ca",
+    "zh:415965fd915bae2040d7f79e45f64d6e3ae61149c10114efeac1b34687d7296c",
+    "zh:6584b2055df0e32062561c615e3b6b2c291ca8c959440adda09ef3ec1e1436bd",
+    "zh:65dcfad71928e0a8dd9befc22524ed686be5020b0024dc5cca5184c7420eeb6b",
+    "zh:7253dc29bd265d33f2791ac4f779c5413f16720bb717de8e6c5fcb2c858648ea",
+    "zh:7ec8993da10a47606670f9f67cfd10719a7580641d11c7aa761121c4a2bd66fb",
+    "zh:999a3f7a9dcf517967fc537e6ec930a8172203642fb01b8e1f78f908373db210",
+    "zh:a50e6df7280eb6584a5fd2456e3f5b6df13b2ec8a7fa4605511e438e1863be42",
+    "zh:b25b329a1e42681c509d027fee0365414f0cc5062b65690cfc3386aab16132ae",
+    "zh:c028877fdb438ece48f7bc02b65bbae9ca7b7befbd260e519ccab6c0cbb39f26",
+    "zh:cf0eaa3ea9fcc6d62793637947f1b8d7c885b6ad74695ab47e134e4ff132190f",
+    "zh:d5ade3fae031cc629b7c512a7b60e46570f4c41665e88a595d7efd943dde5ab2",
+    "zh:f388c15ad1ecfc09e7361e3b98bae9b627a3a85f7b908c9f40650969c949901c",
+    "zh:f415cc6f735a3971faae6ac24034afdb9ee83373ef8de19a9631c187d5adc7db",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,8 +19,8 @@ locals {
   }
 }
 
-# Manually provisioned (no cloud-init); HBA passed through for ZFS. ignore_changes=all
-# keeps Terraform from mutating it — block exists only to capture the spec for rebuilds.
+# Manually provisioned (no cloud-init); HBA passed through for ZFS.
+# prevent_destroy blocks accidental replacement while still allowing drift detection.
 resource "proxmox_vm_qemu" "truenas" {
   vmid        = 101
   name        = "truenas"
@@ -72,22 +72,23 @@ resource "proxmox_vm_qemu" "truenas" {
   }
 
   lifecycle {
-    ignore_changes = all
+    prevent_destroy = true
   }
 }
 
-resource "local_file" "cloud_init_agents" {
-  content = templatefile("cloud_init.tftpl", {
+resource "local_sensitive_file" "cloud_init_agents" {
+  content = sensitive(templatefile("cloud_init.tftpl", {
     hostname           = "docker-host"
     os_family          = "debian"
     tailscale_auth_key = local.proxmox_creds.tailscale_auth_key
     ssh_public_key     = var.docker_host_ssh_public_key
-  })
-  filename = "${path.module}/files/agents.cfg"
+  }))
+  filename        = "${path.module}/files/agents.cfg"
+  file_permission = "0600"
 }
 
 resource "terraform_data" "cloud_init_config" {
-  triggers_replace = [local_file.cloud_init_agents.content]
+  triggers_replace = [local_sensitive_file.cloud_init_agents.content]
   connection {
     type     = "ssh"
     user     = local.proxmox_creds.username
@@ -98,8 +99,11 @@ resource "terraform_data" "cloud_init_config" {
     inline = ["mkdir -p /var/lib/vz/snippets"]
   }
   provisioner "file" {
-    source      = local_file.cloud_init_agents.filename
+    source      = local_sensitive_file.cloud_init_agents.filename
     destination = "/var/lib/vz/snippets/agents.yml"
+  }
+  provisioner "remote-exec" {
+    inline = ["chmod 0600 /var/lib/vz/snippets/agents.yml"]
   }
 }
 
@@ -181,7 +185,7 @@ resource "proxmox_vm_qemu" "cloud_init_docker_host" {
   }
 
   lifecycle {
-    ignore_changes = all
+    prevent_destroy = true
   }
 }
 

--- a/terraform/network/.terraform.lock.hcl
+++ b/terraform/network/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/1password/onepassword" {
+  version     = "3.3.1"
+  constraints = "3.3.1"
+  hashes = [
+    "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
+    "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
+    "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
+    "zh:161bc55c466214a5d425ba85753d74ed5078212db965f726e6650d2e1524d633",
+    "zh:3de4a9f212e1046016a3ace8816e2cb15cfb7b9579161e468a08b9034d6a5f51",
+    "zh:730105346065ea3d2bd6acc6f5fe36f7b8a2b54c513d20a46bcd51d656e82bb4",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c29f6025d099bc8f1f96e7bb4cd66c5d07209b4141d2fd7720228cf20c9c8efd",
+    "zh:d8ea431d396986ca6baf033fa9aaccb73d6a9f9b7d42bea7af8dc73b9ef20297",
+  ]
+}
+
+provider "registry.terraform.io/ubiquiti-community/unifi" {
+  version     = "0.41.25"
+  constraints = "~> 0.41"
+  hashes = [
+    "h1:zwJDyrNyfxz3/iHXVSRO3mVxMrE5VAOM2Q8g7Z2yOnI=",
+    "zh:1f45ce17895b191156c1556cb704e022c903afce13d4d0eb9c7a8c2ba1d5c882",
+    "zh:25350e49be814fa80b0831d598773ef5ca6349875fc84ae8c68c5aeecc8546a6",
+    "zh:2782b11d6d05a30a794b627026057f2a5cd1795c658e0fab35d3b779aa238f42",
+    "zh:2997d531fbccec09ceb5cabba6a8af4c9a346e09ce3dbe659385ada8ae9efca5",
+    "zh:32a715e6249b14b62b5b9dbb99c4879b6f5937da2f1c2c8e5ae567c640836fdf",
+    "zh:42d4dda9ac0113318b8032ce78699131fdb0ae535f477ce3b9f686c0c371cfdf",
+    "zh:439d03f851fc29aa517d886c4e81998b5950a7c8c94fba9091819dd26d2b1910",
+    "zh:44cd68b8d00c41d9de7394ed3f75f8f76de0502d412c42fd6f8ba587a8632ddd",
+    "zh:58c7d69284a9942296e5e9751b368836a958fb07faa729951e2775761ce58f6c",
+    "zh:7b2acfa58bee36965874b1f79269e129b7826edd57c2ece138eb3aedaea3cd1f",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8c6b8d2faca5defb41c001c83985a91c9b8f9e81caec0e5653add5f7e80fe95f",
+    "zh:96d147ee8f62d15e20260de8b04cd1aebed3f76ca81223cdafcb522d88bb90ad",
+    "zh:98f39a5d41aed24290150c10bd7582672df6d9be9789245dd49b6935b2a0557e",
+    "zh:9e287652665f9cfde532855b0b4e2a09f7661ba88d594e36a9169a4acafe7852",
+  ]
+}

--- a/terraform/unifi/.terraform.lock.hcl
+++ b/terraform/unifi/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/1password/onepassword" {
+  version     = "3.3.1"
+  constraints = "3.3.1"
+  hashes = [
+    "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
+    "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
+    "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
+    "zh:161bc55c466214a5d425ba85753d74ed5078212db965f726e6650d2e1524d633",
+    "zh:3de4a9f212e1046016a3ace8816e2cb15cfb7b9579161e468a08b9034d6a5f51",
+    "zh:730105346065ea3d2bd6acc6f5fe36f7b8a2b54c513d20a46bcd51d656e82bb4",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c29f6025d099bc8f1f96e7bb4cd66c5d07209b4141d2fd7720228cf20c9c8efd",
+    "zh:d8ea431d396986ca6baf033fa9aaccb73d6a9f9b7d42bea7af8dc73b9ef20297",
+  ]
+}
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.107.0"
+  constraints = "0.107.0"
+  hashes = [
+    "h1:THU5BKb+B9heDPKkgeARA09ZEY63U1JkOGa0OwCWGI8=",
+    "zh:3c1e298f4f0d954e83d11aaf2400ec242b835ca294f8a94d67bb5ce0b30da0e9",
+    "zh:4776f7f262728f8e2252360f7d1a4adc853d87d86a7515f4780375c2932ef763",
+    "zh:53633a48f7fad5561a30b349e7b46c6a7a10a54c99225a4d30a7a24086921098",
+    "zh:62686df322f773b40c1881eb7932058cbf68101bfa5cd66bc08c9bcb6ad0bdfd",
+    "zh:62afd9992f9089311a876c7e79d35a8b7935c0c553f6de8fb6ac2b76f5c4a3ce",
+    "zh:6b379f3858ba8bd548b7d50c07f7fb7eb339d2020c07c2b69aaba1f2247aedae",
+    "zh:8a520d7df039cb060182683d823d1705423cd9e97936b8e65a27dbf54ea9643a",
+    "zh:b489993495332d3d4aedfd53a7ff80ce880a58ec575bf3340646791c1803862c",
+    "zh:db164bc934aaeb56ae1b368208c7cd33f5af5ac84dc98fa7da736a62a5ede143",
+    "zh:eeb9611c160baf65e6acede202b9d923d185395af2725425c2f8226403675155",
+    "zh:f24b8014a513483cef883caf58884a380fb51567e50ea5425a3d5ec6629f4a9b",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+    "zh:f329a8f344ec11c64686a0b29cd706f5dfedb19925a58aa61fb39f0d0a854619",
+    "zh:ff0a8a1ac74eaef2826054982d82cb42f1376dac98f3d30f995d60f4964ee7b1",
+  ]
+}


### PR DESCRIPTION
## Summary
- replace broad VM `ignore_changes = all` on TrueNAS and docker-host with `prevent_destroy` so drift is visible while accidental replacement is blocked
- make docker-host cloud-init output sensitive and `0600` locally/remotely
- commit Terraform provider lock files and stop ignoring them
- run Terraform `just` recipes with `umask 077` and document local state as secret-bearing

## Validation
- `terraform -chdir=terraform fmt -check -recursive`
- `terraform -chdir=terraform validate` (passes with existing Telmate USB deprecation warning)
- `terraform -chdir=terraform/network validate`
- `terraform -chdir=terraform/unifi validate`