### PR TITLE
fix(ansible): tighten ssh hardening and reduce repeat work

### DIFF
--- a/ansible/roles/common/tasks/ssh.yaml
+++ b/ansible/roles/common/tasks/ssh.yaml
@@ -2,49 +2,55 @@
 - name: disable root login
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config"
-    regexp: "^(#\\s*)?PermitRootLogin (yes|no|prohibit-password|forced-commands-only)"
+    regexp: "^\\s*#?\\s*PermitRootLogin\\s+.*$"
     line: "PermitRootLogin no"
     state: present
+  notify: "restart sshd service"
 
 - name: disable password authentication
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config"
-    regexp: "^(#\\s*)?PasswordAuthentication (yes|no)"
+    regexp: "^\\s*#?\\s*PasswordAuthentication\\s+.*$"
     line: "PasswordAuthentication no"
     state: present
+  notify: "restart sshd service"
 
 - name: disable any keyboard interactive authentication
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config"
-    regexp: "^(#\\s*)KbdInteractiveAuthentication (yes|no)"
+    regexp: "^\\s*#?\\s*KbdInteractiveAuthentication\\s+.*$"
     line: "KbdInteractiveAuthentication no"
     state: present
+  notify: "restart sshd service"
 
 - name: disable x11 forwarding
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config"
-    regexp: "^(#\\s*)X11Forwarding (yes|no)"
+    regexp: "^\\s*#?\\s*X11Forwarding\\s+.*$"
     line: "X11Forwarding no"
     state: present
+  notify: "restart sshd service"
 
 - name: disable ssh-agent forwarding
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config"
-    regexp: "^(#\\s*)AllowAgentForwarding (yes|no)"
+    regexp: "^\\s*#?\\s*AllowAgentForwarding\\s+.*$"
     line: "AllowAgentForwarding no"
     state: present
+  notify: "restart sshd service"
 
 - name: disable unix-domain socket forwarding
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config"
-    regexp: "^(#\\s*)AllowStreamLocalForwarding (yes|no|all|local|remote)"
+    regexp: "^\\s*#?\\s*AllowStreamLocalForwarding\\s+.*$"
     line: "AllowStreamLocalForwarding no"
     state: present
+  notify: "restart sshd service"
 
 - name: set authentication methods to publickey
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config"
-    regexp: "^(#\\s*)AuthenticationMethods .*"
+    regexp: "^\\s*#?\\s*AuthenticationMethods\\s+.*$"
     line: "AuthenticationMethods publickey"
     state: present
   notify: "restart sshd service"

--- a/ansible/roles/media/tasks/nfs.yaml
+++ b/ansible/roles/media/tasks/nfs.yaml
@@ -34,25 +34,16 @@
         owner: "media"
         group: "media"
 
-- name: check whether mount folders exist
-  ansible.builtin.stat:
+- name: create folders for nfs mounts
+  ansible.builtin.file:
     path: "{{ item.local_path }}"
-  register: mount_folders_stat
+    state: directory
+    mode: "0775"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
   loop: "{{ nfs_mounts }}"
   loop_control:
     label: "{{ item.name }}"
-
-- name: create missing folders for nfs mounts
-  ansible.builtin.file:
-    path: "{{ item.item.local_path }}"
-    state: directory
-    mode: "0775"
-    owner: "{{ item.item.owner }}"
-    group: "{{ item.item.group }}"
-  when: not item.stat.exists
-  loop: "{{ mount_folders_stat.results }}"
-  loop_control:
-    label: "{{ item.item.name }}"
 
 - name: mount nfs shares
   ansible.posix.mount:

--- a/ansible/roles/unifi/tasks/main.yaml
+++ b/ansible/roles/unifi/tasks/main.yaml
@@ -14,6 +14,7 @@
       - apt-transport-https
     state: present
     update_cache: true
+    cache_valid_time: 3600
 
 # UniFi Network 10.x requires Java 25, which Debian 12 doesn't ship. Pull
 # Eclipse Temurin from Adoptium.
@@ -33,12 +34,6 @@
     repo: "deb [signed-by=/etc/apt/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bookworm main"
     filename: adoptium
     state: present
-
-- name: install temurin jre
-  ansible.builtin.apt:
-    name: "temurin-{{ unifi_java_version }}-jre"
-    state: present
-    update_cache: true
 
 # --- MongoDB (binary only; UniFi runs its own mongod instance on :27117) ---
 - name: download mongodb signing key
@@ -63,21 +58,6 @@
     filename: "mongodb-org-{{ mongodb_version }}"
     state: present
 
-- name: install mongodb server
-  ansible.builtin.apt:
-    name: mongodb-org-server
-    state: present
-    update_cache: true
-
-# UniFi spawns + manages its own mongod on :27117; the packaged systemd instance
-# (:27017) is redundant and wastes RAM on a memory-constrained host.
-- name: disable redundant system mongod instance
-  ansible.builtin.systemd:
-    name: mongod
-    enabled: false
-    state: stopped
-  failed_when: false
-
 # --- UniFi Network controller ---
 - name: download unifi signing key
   ansible.builtin.get_url:
@@ -91,11 +71,23 @@
     filename: unifi
     state: present
 
-- name: install unifi controller
+- name: install unifi packages
   ansible.builtin.apt:
-    name: unifi
+    name:
+      - "temurin-{{ unifi_java_version }}-jre"
+      - mongodb-org-server
+      - unifi
     state: present
     update_cache: true
+
+# UniFi spawns + manages its own mongod on :27117; the packaged systemd instance
+# (:27017) is redundant and wastes RAM on a memory-constrained host.
+- name: disable redundant system mongod instance
+  ansible.builtin.systemd:
+    name: mongod
+    enabled: false
+    state: stopped
+  failed_when: false
 
 - name: enable and start unifi
   ansible.builtin.systemd:


### PR DESCRIPTION
## Summary
- make SSH hardening regexes replace active insecure directives, not only commented defaults
- notify the sshd restart handler for every sshd_config hardening change
- consolidate UniFi external package installs into one apt cache refresh after repos are configured
- remove the redundant NFS directory stat loop and rely on the idempotent file module

## Verification
- `ANSIBLE_LOCAL_TEMP=/private/tmp/ansible-local TMPDIR=/private/tmp ansible-playbook run.yaml --syntax-check --vault-password-file .vaultpass`

Note: syntax check still emits the existing inventory group-name warning.