### PR TITLE
fix(network): allow scoped MGMT WiFi admin access

### DIFF
--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -30,16 +30,17 @@ routeros_mgmt_subnet: 10.77.1.0/24
 routeros_admin_station: 10.77.1.241 # this Mac (MGMT) — see note: DHCP, reserve a lease before default-drop
 routeros_ipmi_host: 10.77.1.99 # Proxmox IPMI/BMC
 routeros_unifi_ctrl: 10.77.1.10
-# Static/reserved admin sources. This drives RouterOS service ACLs, input allow-list,
-# and privileged inter-VLAN access; add VPN/admin hosts here rather than widening MGMT.
+# Admin plane = the whole MGMT subnet. The hidden WPA3 MGMT SSID (madviLANy-mgmt)
+# lands clients untagged on VLAN 1, so any MGMT host — wired or over WiFi — can
+# manage the router, controller and IPMI without depending on a single reserved IP.
+# This drives RouterOS service ACLs, the input allow-list, and privileged inter-VLAN access.
 routeros_admin_sources:
-  - "{{ routeros_admin_station }}"
+  - "{{ routeros_mgmt_subnet }}"
 routeros_mgmt_admin_sources: "{{ routeros_admin_sources | join(',') }}"
 
-# MGMT hosts that need internet egress. Do not grant the whole MGMT subnet lateral access.
+# MGMT hosts that need internet egress — the whole MGMT subnet (admin plane).
 routeros_mgmt_wan_sources:
-  - "{{ routeros_admin_station }}"
-  - "{{ routeros_unifi_ctrl }}"
+  - "{{ routeros_mgmt_subnet }}"
 
 # Tagged on the trunk bridge; MGMT/VLAN 1 is the untagged net.
 routeros_vlans:

--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -42,12 +42,6 @@ routeros_mgmt_admin_sources: "{{ routeros_router_admin_sources | join(',') }}"
 routeros_admin_sources:
   - "{{ routeros_mgmt_subnet }}"
 
-# MGMT hosts that need internet egress. Management WiFi clients do not require
-# WAN access just to reach the router, UniFi controller, or IPMI on VLAN 1.
-routeros_mgmt_wan_sources:
-  - "{{ routeros_admin_station }}"
-  - "{{ routeros_unifi_ctrl }}"
-
 # Tagged on the trunk bridge; MGMT/VLAN 1 is the untagged net.
 routeros_vlans:
   - { id: 20, name: srv, subnet: 10.77.20.0/24, gateway: 10.77.20.1, pool_start: 10.77.20.50, pool_end: 10.77.20.250 }

--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -37,10 +37,10 @@ routeros_router_admin_sources:
   - "{{ routeros_mgmt_subnet }}"
 routeros_mgmt_admin_sources: "{{ routeros_router_admin_sources | join(',') }}"
 
-# Privileged routed access stays narrow. Do not grant all MGMT WiFi clients
-# lateral access to internal VLANs.
+# MGMT WiFi is trusted as an admin network, so MGMT clients may administer
+# internal VLAN hosts without needing reserved DHCP leases per device.
 routeros_admin_sources:
-  - "{{ routeros_admin_station }}"
+  - "{{ routeros_mgmt_subnet }}"
 
 # MGMT hosts that need internet egress. Management WiFi clients do not require
 # WAN access just to reach the router, UniFi controller, or IPMI on VLAN 1.

--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -30,17 +30,23 @@ routeros_mgmt_subnet: 10.77.1.0/24
 routeros_admin_station: 10.77.1.241 # this Mac (MGMT) — see note: DHCP, reserve a lease before default-drop
 routeros_ipmi_host: 10.77.1.99 # Proxmox IPMI/BMC
 routeros_unifi_ctrl: 10.77.1.10
-# Admin plane = the whole MGMT subnet. The hidden WPA3 MGMT SSID (madviLANy-mgmt)
-# lands clients untagged on VLAN 1, so any MGMT host — wired or over WiFi — can
-# manage the router, controller and IPMI without depending on a single reserved IP.
-# This drives RouterOS service ACLs, the input allow-list, and privileged inter-VLAN access.
-routeros_admin_sources:
+# Router management is allowed from the whole MGMT subnet. The hidden WPA3 MGMT
+# SSID lands clients untagged on VLAN 1, so DHCP WiFi clients can manage the
+# router without depending on a single reserved IP.
+routeros_router_admin_sources:
   - "{{ routeros_mgmt_subnet }}"
-routeros_mgmt_admin_sources: "{{ routeros_admin_sources | join(',') }}"
+routeros_mgmt_admin_sources: "{{ routeros_router_admin_sources | join(',') }}"
 
-# MGMT hosts that need internet egress — the whole MGMT subnet (admin plane).
+# Privileged routed access stays narrow. Do not grant all MGMT WiFi clients
+# lateral access to internal VLANs.
+routeros_admin_sources:
+  - "{{ routeros_admin_station }}"
+
+# MGMT hosts that need internet egress. Management WiFi clients do not require
+# WAN access just to reach the router, UniFi controller, or IPMI on VLAN 1.
 routeros_mgmt_wan_sources:
-  - "{{ routeros_mgmt_subnet }}"
+  - "{{ routeros_admin_station }}"
+  - "{{ routeros_unifi_ctrl }}"
 
 # Tagged on the trunk bridge; MGMT/VLAN 1 is the untagged net.
 routeros_vlans:

--- a/ansible/group_vars/unifi.yaml
+++ b/ansible/group_vars/unifi.yaml
@@ -6,11 +6,11 @@ ssh_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8Ux
 swap_mode: none
 swap_swappiness: 10
 
-unifi_admin_source: 10.77.1.241
+unifi_admin_source: 10.77.1.0/24
 unifi_ap_source: 10.77.1.0/24
 
-# Admin ports are pinned to the admin station; AP-facing ports stay on the MGMT LAN
-# until the AP has a reserved address/subnet that can be narrower.
+# Admin + AP ports are scoped to the MGMT subnet: the MGMT WiFi SSID lands clients
+# on VLAN 1, so the controller GUI/SSH must accept any MGMT host, not one reserved IP.
 # MongoDB (27117) is deliberately absent: it binds localhost only, never expose it.
 # SSH is explicitly allowed because the controller has no Tailscale; its from_ip differs from
 # the firewall role's deleted bare 22/tcp rule so it survives default-deny.

--- a/ansible/roles/routeros/tasks/firewall.yaml
+++ b/ansible/roles/routeros/tasks/firewall.yaml
@@ -49,25 +49,6 @@
         comment: "managed: routeros role"
       {% endfor %}
 
-- name: Address-list for MGMT hosts allowed to reach WAN
-  community.routeros.api_modify:
-    path: ip firewall address-list
-    handle_absent_entries: remove
-    restrict:
-      - field: list
-        values:
-          - mgmt-wan
-      - field: comment
-        regex: "managed: routeros role"
-    data: "{{ _routeros_mgmt_wan_address_list | from_yaml }}"
-  vars:
-    _routeros_mgmt_wan_address_list: |
-      {% for address in routeros_mgmt_wan_sources %}
-      - list: mgmt-wan
-        address: "{{ address }}"
-        comment: "managed: routeros role"
-      {% endfor %}
-
 - name: Input — allow MGMT hosts to manage the router
   community.routeros.api_modify:
     path: ip firewall filter
@@ -142,7 +123,7 @@
         action: accept
         comment: "SRV -> UniFi controller (managed: routeros role)"
       - chain: forward
-        src-address-list: mgmt-wan
+        src-address-list: admin
         out-interface-list: WAN
         action: accept
         comment: "MGMT admins -> WAN (managed: routeros role)"

--- a/ansible/roles/routeros/tasks/firewall.yaml
+++ b/ansible/roles/routeros/tasks/firewall.yaml
@@ -11,35 +11,72 @@
         comment: "managed: routeros role"
   loop: "{{ [routeros_mgmt_subnet, routeros_dmz.subnet] + (routeros_vlans | map(attribute='subnet') | list) }}"
 
-- name: Address-list for admin sources
+- name: Address-list for router management sources
   community.routeros.api_modify:
     path: ip firewall address-list
-    handle_absent_entries: ignore
-    data:
-      - list: admin
-        address: "{{ item }}"
+    handle_absent_entries: remove
+    restrict:
+      - field: list
+        values:
+          - router-admin
+      - field: comment
+        regex: "managed: routeros role"
+    data: "{{ _routeros_router_admin_address_list | from_yaml }}"
+  vars:
+    _routeros_router_admin_address_list: |
+      {% for address in routeros_router_admin_sources %}
+      - list: router-admin
+        address: "{{ address }}"
         comment: "managed: routeros role"
-  loop: "{{ routeros_admin_sources }}"
+      {% endfor %}
+
+- name: Address-list for privileged routed admin sources
+  community.routeros.api_modify:
+    path: ip firewall address-list
+    handle_absent_entries: remove
+    restrict:
+      - field: list
+        values:
+          - admin
+      - field: comment
+        regex: "managed: routeros role"
+    data: "{{ _routeros_admin_address_list | from_yaml }}"
+  vars:
+    _routeros_admin_address_list: |
+      {% for address in routeros_admin_sources %}
+      - list: admin
+        address: "{{ address }}"
+        comment: "managed: routeros role"
+      {% endfor %}
 
 - name: Address-list for MGMT hosts allowed to reach WAN
   community.routeros.api_modify:
     path: ip firewall address-list
-    handle_absent_entries: ignore
-    data:
+    handle_absent_entries: remove
+    restrict:
+      - field: list
+        values:
+          - mgmt-wan
+      - field: comment
+        regex: "managed: routeros role"
+    data: "{{ _routeros_mgmt_wan_address_list | from_yaml }}"
+  vars:
+    _routeros_mgmt_wan_address_list: |
+      {% for address in routeros_mgmt_wan_sources %}
       - list: mgmt-wan
-        address: "{{ item }}"
+        address: "{{ address }}"
         comment: "managed: routeros role"
-  loop: "{{ routeros_mgmt_wan_sources }}"
+      {% endfor %}
 
-- name: Input — allow admin station to manage the router + IPMI host
+- name: Input — allow MGMT hosts to manage the router
   community.routeros.api_modify:
     path: ip firewall filter
     handle_absent_entries: ignore
     data:
       - chain: input
-        src-address-list: admin
+        src-address-list: router-admin
         action: accept
-        comment: "admin -> router (managed: routeros role)"
+        comment: "MGMT -> router (managed: routeros role)"
       - chain: input
         connection-state: established,related
         action: accept

--- a/ansible/roles/routeros/tasks/services.yaml
+++ b/ansible/roles/routeros/tasks/services.yaml
@@ -3,9 +3,9 @@
 - name: Validate RouterOS management service sources
   ansible.builtin.assert:
     that:
-      - routeros_admin_sources | length > 0
-      - routeros_mgmt_admin_sources == (routeros_admin_sources | join(','))
-    fail_msg: routeros_admin_sources is the source of truth for RouterOS management access.
+      - routeros_router_admin_sources | length > 0
+      - routeros_mgmt_admin_sources == (routeros_router_admin_sources | join(','))
+    fail_msg: routeros_router_admin_sources is the source of truth for RouterOS management access.
 
 - name: Disable insecure / unused management services
   community.routeros.api_modify:
@@ -21,7 +21,7 @@
       - name: api # plain (cleartext) API; we use api-ssl only
         disabled: true
 
-# LOCKOUT NOTE: admin station + controller are on MGMT, so this keeps access. Widen routeros_mgmt_admin_sources to manage off-LAN.
+# LOCKOUT NOTE: router management is allowed from MGMT, so WiFi DHCP clients are not pinned to one reserved IP.
 - name: Restrict encrypted management services to MGMT
   community.routeros.api_modify:
     path: ip service


### PR DESCRIPTION
## Summary
Stacks on #1447. That PR pinned RouterOS management service access, RouterOS input/forward `admin` rules, and the UniFi controller `ufw` admin allows to the single wired IP `10.77.1.241`.

The hidden WPA3 MGMT SSID (`madviLANy-mgmt`) lands clients untagged on VLAN 1 with DHCP addresses in `10.77.1.0/24`. Anything on MGMT WiFi is trusted as an admin device, so those clients should be able to access management targets, administer internal hosts, and use WAN egress without depending on one reserved IP:

- router management (winbox/ssh/api-ssl/www-ssl)
- UniFi controller GUI `:8443` / ssh
- IPMI `10.77.1.99` (same-subnet L2; not routed through RouterOS)
- routed admin access to internal VLANs
- internet/WAN egress

## Change
Treat the MGMT subnet as the trusted admin network:

- `routeros_router_admin_sources` -> `[10.77.1.0/24]` for RouterOS service ACLs and router input access.
- `routeros_admin_sources` -> `[10.77.1.0/24]` for trusted MGMT admin access to internal VLANs and WAN egress.
- Removed the separate `routeros_mgmt_wan_sources` / `mgmt-wan` policy path because it is unnecessary once MGMT WiFi is trusted.
- `unifi_admin_source` -> `10.77.1.0/24` so the controller host firewall accepts GUI/SSH from MGMT WiFi clients.

The RouterOS address-list tasks now reconcile the managed `router-admin` and `admin` entries with `handle_absent_entries: remove`, scoped by list/comment. That removes stale broad or narrow managed entries if an earlier version of this PR was applied.

## Notes
- IPMI is expected to work over the same untagged MGMT L2 segment. If it does not, check UniFi WLAN/client isolation or VLAN/native network config rather than RouterOS forward policy.
- The resulting policy is simple: MGMT WiFi is an admin network.
