### PR TITLE
fix(network): require wired management access

### DIFF
--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -39,16 +39,16 @@ routeros_mgmt_subnet: 10.77.1.0/24
 routeros_admin_station: 10.77.1.241 # this Mac (MGMT) — see note: DHCP, reserve a lease before default-drop
 routeros_ipmi_host: 10.77.1.99 # Proxmox IPMI/BMC
 routeros_unifi_ctrl: 10.77.1.10
-# Router management is allowed from the whole MGMT subnet. The hidden WPA3 MGMT
-# SSID lands clients untagged on VLAN 1, so DHCP WiFi clients can manage the
-# router without depending on a single reserved IP.
+# Router management is allowed from the wired MGMT subnet plus the dedicated OOB
+# recovery link. MGMT is intentionally not exposed by a WiFi SSID.
 routeros_router_admin_sources:
   - "{{ routeros_mgmt_subnet }}"
   - "{{ routeros_oob_subnet }}" # out-of-band port can always manage the router
 routeros_mgmt_admin_sources: "{{ routeros_router_admin_sources | join(',') }}"
 
-# MGMT WiFi is trusted as an admin network, so MGMT clients may administer
-# internal VLAN hosts without needing reserved DHCP leases per device.
+# Wired MGMT is trusted for same-VLAN infrastructure management. It is not a
+# blanket routed bypass into SRV/DFLT/KDS/GST/DMZ; add explicit forward rules
+# only for routed management targets that genuinely need them.
 routeros_admin_sources:
   - "{{ routeros_mgmt_subnet }}"
 
@@ -66,6 +66,27 @@ routeros_dmz:
   gateway: 10.77.99.1
   pool_start: 10.77.99.50
   pool_end: 10.77.99.250
+
+# Named policy objects. Keep these derived from the topology data above so the
+# firewall role reads by intent without duplicating subnet/interface literals.
+routeros_vlan_subnets: "{{ routeros_vlans | map(attribute='subnet') | list }}"
+routeros_internal_subnets: "{{ [routeros_mgmt_subnet, routeros_dmz.subnet] + routeros_vlan_subnets }}"
+routeros_lan_input_interfaces: >-
+  {{
+    [routeros_bridge]
+    + (routeros_vlans | map(attribute='id') | zip(routeros_vlans | map(attribute='name')) | map('join', '-') | map('regex_replace', '^', 'vlan') | list)
+    + ([routeros_dmz_port] if routeros_enable_dmz | bool else [])
+  }}
+routeros_router_lan_interfaces: >-
+  {{
+    (routeros_vlans | map(attribute='id') | zip(routeros_vlans | map(attribute='name')) | map('join', '-') | map('regex_replace', '^', 'vlan') | list)
+    + ([routeros_dmz_port] if routeros_enable_dmz | bool else [])
+  }}
+routeros_wan_egress_subnets: >-
+  {{
+    routeros_vlan_subnets
+    + ([routeros_dmz.subnet] if routeros_enable_dmz | bool else [])
+  }}
 
 routeros_default_dns: 10.77.1.1
 routeros_kids_dns: 1.1.1.3 # OPEN ITEM: Cloudflare Families / NextDNS / AdGuard

--- a/ansible/group_vars/unifi.yaml
+++ b/ansible/group_vars/unifi.yaml
@@ -9,8 +9,8 @@ swap_swappiness: 10
 unifi_admin_source: 10.77.1.0/24
 unifi_ap_source: 10.77.1.0/24
 
-# Admin + AP ports are scoped to the MGMT subnet: the MGMT WiFi SSID lands clients
-# on VLAN 1, so the controller GUI/SSH must accept any MGMT host, not one reserved IP.
+# Admin + AP ports are scoped to the MGMT subnet: MGMT is wired-only on VLAN 1, so the
+# controller GUI/SSH must accept any wired MGMT host, not one reserved IP.
 # MongoDB (27117) is deliberately absent: it binds localhost only, never expose it.
 # SSH is explicitly allowed because the controller has no Tailscale; its from_ip differs from
 # the firewall role's deleted bare 22/tcp rule so it survives default-deny.

--- a/ansible/roles/routeros/README.md
+++ b/ansible/roles/routeros/README.md
@@ -39,6 +39,13 @@ services restricted to `routeros_router_admin_sources` (MGMT + OOB subnets).
 `routeros_enable_vlan_filtering` / `routeros_enable_default_drop` default to
 `false`, and the vlan-filtering flip is additionally `never`-tagged.
 
+The run ends with read-only verification. To run only the checks:
+
+```sh
+cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass \
+  --limit routeros --tags verify
+```
+
 ## Lockout-risk flips (explicit, one at a time)
 
 ⚠️ A 2026-06-03 apply that enabled vlan-filtering with MGMT bound to the raw bridge
@@ -52,13 +59,22 @@ cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass \
 # Then VERIFY MGMT still works: a DHCP client on VLAN 1 still pulls a lease,
 # and 10.77.1.1 is reachable. If not, disable filtering from the OOB port.
 
-# 2. Only once filtering is verified, enable the forward default-drop:
+# 2. Only once filtering is verified, enable the forward default-drop.
+# This requires routeros_enable_default_drop=true AND an explicit default-drop tag:
 cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass \
   --limit routeros --tags firewall,default-drop -e routeros_enable_default_drop=true
 ```
 
-After any flip, inspect `/interface bridge vlan print`, `/interface bridge port print`,
-`/ip dhcp-server print`, and `/ip firewall filter print`.
+After any flip, run the read-only verifier:
+
+```sh
+cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass \
+  --limit routeros --tags verify -e routeros_enable_vlan_filtering=true \
+  -e routeros_enable_default_drop=true
+```
+
+Also inspect `/interface bridge vlan print`, `/interface bridge port print`,
+`/ip dhcp-server print`, and `/ip firewall filter print` if a check fails.
 
 ## MGMT / VLAN 1 DHCP (why it stays on the raw bridge)
 
@@ -76,3 +92,17 @@ VLAN 1 CPU delivery from the raw-bridge IP); that approach was abandoned for thi
 
 ⚠️ This binding is unverified under live vlan-filtering. Before trusting it: enable
 filtering from the OOB port and confirm a VLAN 1 client still pulls a DHCP lease.
+
+## Proxmox host topology
+
+The RouterOS port map assumes the Proxmox host is cabled and bridged like this:
+
+- `eno2` -> `vmbr0` -> RB5009 `ether3`: production/MGMT uplink. The host address
+  is `10.77.1.100/24` with gateway `10.77.1.1`; VMs/LXCs without an explicit VLAN tag
+  land on native MGMT.
+- `eno1` -> `vmbr1` -> RB5009 `ether2`: untagged DMZ uplink. The Proxmox host should
+  not have an IP on this bridge; ai-dev guests on `vmbr1` get DHCP from `10.77.99.1`.
+
+Keep `vmbr1` as an untagged bridge unless there is a deliberate need to trunk VLANs into
+the DMZ. Allowing all VLAN IDs on the DMZ bridge makes the host side broader than the
+RouterOS model, which treats `ether2` as a single untagged L3 DMZ interface.

--- a/ansible/roles/routeros/tasks/firewall.yaml
+++ b/ansible/roles/routeros/tasks/firewall.yaml
@@ -9,7 +9,7 @@
       - list: internal
         address: "{{ item }}"
         comment: "managed: routeros role"
-  loop: "{{ [routeros_mgmt_subnet, routeros_dmz.subnet] + (routeros_vlans | map(attribute='subnet') | list) }}"
+  loop: "{{ routeros_internal_subnets }}"
 
 - name: Address-list for router management sources
   community.routeros.api_modify:
@@ -51,23 +51,32 @@
 
 # The defconf input chain ends with `drop chain=input in-interface-list=!LAN`. MGMT
 # rides the bridge, which defconf already put in LAN, so MGMT DHCP/DNS to the router
-# survives. The routed VLAN interfaces and the de-bridged DMZ port are NOT in LAN, so
-# their router-bound DHCP/DNS would hit that drop (the managed input accepts below get
-# appended AFTER the defconf drop, so they cannot rescue it). Add the interfaces to LAN
-# so they ride the defconf input accepts like MGMT does. Sensitive management services
-# stay pinned to the MGMT source list (services.yaml), so LAN membership only opens
-# DHCP/DNS/ICMP to the router here — not Winbox/SSH/API.
+# survives. The routed VLAN interfaces, the de-bridged DMZ port and the OOB port are
+# NOT in LAN, so their router-bound traffic would hit that drop (the managed input
+# accepts below get appended AFTER the defconf drop, so they cannot rescue it). Add
+# client VLANs/DMZ for DHCP/DNS and OOB for break-glass router input. Sensitive
+# management services stay source-pinned in services.yaml; OOB routed traffic is
+# explicitly dropped in the forward chain below.
 - name: Add routed VLAN + DMZ interfaces to the LAN interface-list
   community.routeros.api_modify:
     path: interface list member
     handle_absent_entries: ignore
     data:
       - list: LAN
-        interface: "{{ ('vlan' ~ item.id ~ '-' ~ item.name) if item.name != 'dmz' else routeros_dmz_port }}"
-        comment: "{{ item.name }} in LAN (managed: routeros role)"
-  loop: "{{ routeros_vlans + ([routeros_dmz] if routeros_enable_dmz | bool else []) }}"
+        interface: "{{ item }}"
+        comment: "{{ item }} in LAN (managed: routeros role)"
+  loop: "{{ routeros_router_lan_interfaces }}"
   loop_control:
-    label: "{{ item.name }}"
+    label: "{{ item }}"
+
+- name: Add OOB to the LAN interface-list for router recovery input
+  community.routeros.api_modify:
+    path: interface list member
+    handle_absent_entries: ignore
+    data:
+      - list: LAN
+        interface: "{{ routeros_oob_port }}"
+        comment: "oob in LAN for router input (managed: routeros role)"
 
 - name: Input — allow MGMT hosts + the router's own services
   community.routeros.api_modify:
@@ -82,14 +91,8 @@
     # DHCP DISCOVER comes from 0.0.0.0, so
     # scope it by ingress interface (not source address) to keep it off the WAN. MGMT
     # rides the raw bridge (native VLAN 1), the routed VLANs their vlanX interfaces.
-    _routeros_dhcp_input_interfaces: >-
-      {{
-        [routeros_bridge]
-        + (routeros_vlans | map(attribute='id') | zip(routeros_vlans | map(attribute='name')) | map('join', '-') | map('regex_replace', '^', 'vlan') | list)
-        + ([routeros_dmz_port] if routeros_enable_dmz | bool else [])
-      }}
     _routeros_input_policy: |
-      {% for interface in _routeros_dhcp_input_interfaces %}
+      {% for interface in routeros_lan_input_interfaces %}
       - chain: input
         in-interface: "{{ interface }}"
         protocol: udp
@@ -126,6 +129,13 @@
         action: drop
         comment: "input drop invalid (managed: routeros role)"
 
+- name: Require explicit default-drop tag for default-drop enablement
+  ansible.builtin.assert:
+    that:
+      - "'default-drop' in ansible_run_tags"
+    fail_msg: "routeros_enable_default_drop=true requires an explicit --tags firewall,default-drop run."
+  when: routeros_enable_default_drop | bool
+
 - name: Forward — ordered managed policy
   community.routeros.api_modify:
     path: ip firewall filter
@@ -140,7 +150,8 @@
     data: "{{ _routeros_forward_policy }}"
   vars:
     _net: "{{ routeros_vlans | items2dict(key_name='name', value_name='subnet') }}"
-    _routeros_forward_base_policy:
+    _routeros_forward_base_policy: "{{ _routeros_forward_base_policy_yaml | from_yaml }}"
+    _routeros_forward_base_policy_yaml: |
       - chain: forward
         connection-state: established,related
         action: accept
@@ -149,6 +160,10 @@
         connection-state: invalid
         action: drop
         comment: "fwd drop invalid (managed: routeros role)"
+      - chain: forward
+        src-address: "{{ routeros_oob_subnet }}"
+        action: drop
+        comment: "OOB drop routed traffic (managed: routeros role)"
       - chain: forward
         src-address: "{{ _net.kds }}"
         protocol: tcp
@@ -161,11 +176,6 @@
         dst-port: 853
         action: drop
         comment: "KDS drop DoQ (managed: routeros role)"
-      - chain: forward
-        src-address-list: admin
-        dst-address-list: internal
-        action: accept
-        comment: "admin -> internal (managed: routeros role)"
       - chain: forward
         src-address: "{{ _net.dflt }}"
         dst-address: "{{ _net.srv }}"
@@ -186,31 +196,13 @@
         out-interface-list: WAN
         action: accept
         comment: "MGMT admins -> WAN (managed: routeros role)"
+      {% for subnet in routeros_wan_egress_subnets %}
       - chain: forward
-        src-address: "{{ _net.srv }}"
+        src-address: "{{ subnet }}"
         out-interface-list: WAN
         action: accept
-        comment: "srv -> WAN (managed: routeros role)"
-      - chain: forward
-        src-address: "{{ _net.dflt }}"
-        out-interface-list: WAN
-        action: accept
-        comment: "dflt -> WAN (managed: routeros role)"
-      - chain: forward
-        src-address: "{{ _net.kds }}"
-        out-interface-list: WAN
-        action: accept
-        comment: "kds -> WAN (managed: routeros role)"
-      - chain: forward
-        src-address: "{{ _net.gst }}"
-        out-interface-list: WAN
-        action: accept
-        comment: "gst -> WAN (managed: routeros role)"
-      - chain: forward
-        src-address: "{{ routeros_dmz.subnet }}"
-        out-interface-list: WAN
-        action: accept
-        comment: "dmz -> WAN (managed: routeros role)"
+        comment: "{{ subnet }} -> WAN (managed: routeros role)"
+      {% endfor %}
     _routeros_default_drop_rule:
       - chain: forward
         action: drop
@@ -277,22 +269,22 @@
         | map(attribute='comment')
         | list
       }}
-    _expected_managed_forward_comments:
-      - "fwd est/rel (managed: routeros role)"
-      - "fwd drop invalid (managed: routeros role)"
-      - "KDS drop DoT (managed: routeros role)"
-      - "KDS drop DoQ (managed: routeros role)"
-      - "admin -> internal (managed: routeros role)"
-      - "DFLT -> SRV services (managed: routeros role)"
-      - "KDS -> SRV (Plex/Jellyfin) (managed: routeros role)"
-      - "SRV -> UniFi controller (managed: routeros role)"
-      - "MGMT admins -> WAN (managed: routeros role)"
-      - "srv -> WAN (managed: routeros role)"
-      - "dflt -> WAN (managed: routeros role)"
-      - "kds -> WAN (managed: routeros role)"
-      - "gst -> WAN (managed: routeros role)"
-      - "dmz -> WAN (managed: routeros role)"
-      - "DEFAULT DROP (managed: routeros role)"
+    _expected_managed_forward_comments: >-
+      {{
+        [
+          "fwd est/rel (managed: routeros role)",
+          "fwd drop invalid (managed: routeros role)",
+          "OOB drop routed traffic (managed: routeros role)",
+          "KDS drop DoT (managed: routeros role)",
+          "KDS drop DoQ (managed: routeros role)",
+          "DFLT -> SRV services (managed: routeros role)",
+          "KDS -> SRV (Plex/Jellyfin) (managed: routeros role)",
+          "SRV -> UniFi controller (managed: routeros role)",
+          "MGMT admins -> WAN (managed: routeros role)"
+        ]
+        + (routeros_wan_egress_subnets | map('regex_replace', '$', ' -> WAN (managed: routeros role)') | list)
+        + ["DEFAULT DROP (managed: routeros role)"]
+      }}
   when: routeros_enable_default_drop | bool
   tags: [default-drop]
 

--- a/ansible/roles/routeros/tasks/main.yaml
+++ b/ansible/roles/routeros/tasks/main.yaml
@@ -30,3 +30,7 @@
 - name: Bridge VLAN membership + filtering (lockout-risk flip is gated)
   ansible.builtin.import_tasks: bridge.yaml
   tags: [bridge]
+
+- name: Read-only post-change verification
+  ansible.builtin.import_tasks: verify.yaml
+  tags: [verify]

--- a/ansible/roles/routeros/tasks/services.yaml
+++ b/ansible/roles/routeros/tasks/services.yaml
@@ -21,7 +21,8 @@
       - name: api # plain (cleartext) API; we use api-ssl only
         disabled: true
 
-# LOCKOUT NOTE: router management is allowed from MGMT, so WiFi DHCP clients are not pinned to one reserved IP.
+# LOCKOUT NOTE: router management is allowed from the whole wired MGMT subnet (plus the OOB
+# /30), so any wired MGMT DHCP client can manage the router without a pinned reserved IP.
 - name: Restrict encrypted management services to MGMT
   community.routeros.api_modify:
     path: ip service

--- a/ansible/roles/routeros/tasks/verify.yaml
+++ b/ansible/roles/routeros/tasks/verify.yaml
@@ -1,0 +1,153 @@
+---
+- name: Verify OOB address exists
+  community.routeros.api:
+    path: ip address
+    query: ".id address interface comment WHERE interface == {{ routeros_oob_port }}"
+  register: _routeros_verify_oob_ip
+  check_mode: false
+
+- name: Verify DMZ address exists
+  community.routeros.api:
+    path: ip address
+    query: ".id address interface comment WHERE interface == {{ routeros_dmz_port }}"
+  register: _routeros_verify_dmz_ip
+  check_mode: false
+  when: routeros_enable_dmz | bool
+
+- name: Verify bridge port membership
+  community.routeros.api:
+    path: interface bridge port
+    query: ".id interface bridge pvid"
+  register: _routeros_verify_bridge_ports
+  check_mode: false
+
+- name: Verify bridge VLAN filtering state
+  community.routeros.api:
+    path: interface bridge
+    query: ".id name vlan-filtering WHERE name == {{ routeros_bridge }}"
+  register: _routeros_verify_bridge
+  check_mode: false
+
+- name: Verify LAN interface-list membership
+  community.routeros.api:
+    path: interface list member
+    query: ".id list interface comment WHERE list == LAN"
+  register: _routeros_verify_lan_members
+  check_mode: false
+
+- name: Verify forward filter rules
+  community.routeros.api:
+    path: ip firewall filter
+    query: ".id chain action comment WHERE chain == forward"
+  register: _routeros_verify_forward_filter
+  check_mode: false
+
+- name: Verify DHCP servers
+  community.routeros.api:
+    path: ip dhcp-server
+    query: ".id name interface"
+  register: _routeros_verify_dhcp_servers
+  check_mode: false
+
+- name: Assert OOB and DMZ topology is staged
+  ansible.builtin.assert:
+    that:
+      - _oob_ip_matches | length > 0
+      - routeros_oob_port not in _bridge_port_interfaces
+      - not (routeros_enable_dmz | bool) or _dmz_ip_matches | length > 0
+      - not (routeros_enable_dmz | bool) or routeros_dmz_port not in _bridge_port_interfaces
+    fail_msg: OOB/DMZ topology does not match the intended isolated-port design.
+  vars:
+    _oob_ip_matches: >-
+      {{
+        _routeros_verify_oob_ip.msg
+        | select('mapping')
+        | selectattr('address', 'equalto', routeros_oob_ip)
+        | selectattr('interface', 'equalto', routeros_oob_port)
+        | list
+      }}
+    _dmz_expected_ip: "{{ routeros_dmz.gateway ~ '/' ~ routeros_dmz.subnet.split('/')[1] }}"
+    _dmz_ip_matches: >-
+      {{
+        (_routeros_verify_dmz_ip.msg | default([]))
+        | select('mapping')
+        | selectattr('address', 'equalto', _dmz_expected_ip)
+        | selectattr('interface', 'equalto', routeros_dmz_port)
+        | list
+      }}
+    _bridge_port_interfaces: >-
+      {{
+        _routeros_verify_bridge_ports.msg
+        | select('mapping')
+        | map(attribute='interface')
+        | list
+      }}
+
+- name: Assert router-facing interfaces are in LAN
+  ansible.builtin.assert:
+    that:
+      - _expected_lan_interfaces | difference(_lan_member_interfaces) | length == 0
+    fail_msg: "Missing LAN interface-list members: {{ _expected_lan_interfaces | difference(_lan_member_interfaces) }}"
+  vars:
+    _expected_lan_interfaces: "{{ routeros_router_lan_interfaces + [routeros_oob_port] }}"
+    _lan_member_interfaces: >-
+      {{
+        _routeros_verify_lan_members.msg
+        | select('mapping')
+        | map(attribute='interface')
+        | list
+      }}
+
+- name: Assert DHCP server interfaces are present
+  ansible.builtin.assert:
+    that:
+      - routeros_lan_input_interfaces | difference(_dhcp_interfaces) | length == 0
+    fail_msg: "Missing DHCP server interfaces: {{ routeros_lan_input_interfaces | difference(_dhcp_interfaces) }}"
+  vars:
+    _dhcp_interfaces: >-
+      {{
+        _routeros_verify_dhcp_servers.msg
+        | select('mapping')
+        | map(attribute='interface')
+        | list
+      }}
+
+- name: Assert vlan-filtering state matches the enable flag
+  ansible.builtin.assert:
+    that:
+      - (_bridge_filtering_enabled | bool) == (routeros_enable_vlan_filtering | bool)
+    fail_msg: "Bridge vlan-filtering state does not match routeros_enable_vlan_filtering."
+  vars:
+    _bridge_record: "{{ _routeros_verify_bridge.msg | select('mapping') | first }}"
+    _bridge_filtering_enabled: "{{ _bridge_record['vlan-filtering'] | default(false) }}"
+
+- name: Assert default-drop state matches the enable flag
+  ansible.builtin.assert:
+    that:
+      - not (routeros_enable_default_drop | bool) or _managed_forward_comments[-1] == "DEFAULT DROP (managed: routeros role)"
+      - routeros_enable_default_drop | bool or "DEFAULT DROP (managed: routeros role)" not in _managed_forward_comments
+    fail_msg: Managed forward default-drop state does not match routeros_enable_default_drop.
+  vars:
+    _managed_forward_comments: >-
+      {{
+        _routeros_verify_forward_filter.msg
+        | select('mapping')
+        | selectattr('comment', 'defined')
+        | selectattr('comment', 'search', 'managed: routeros role')
+        | map(attribute='comment')
+        | list
+      }}
+
+- name: Assert no unmanaged accepts are above default drop
+  ansible.builtin.assert:
+    that:
+      - >-
+        item.action | default('') != 'accept'
+        or (item.comment | default('')) is search('managed: routeros role|defconf')
+    fail_msg: "Unmanaged accept rule appears above managed default-drop: {{ item }}"
+  loop: "{{ _forward_filter_records[:_default_drop_index | int] }}"
+  vars:
+    _forward_filter_records: "{{ _routeros_verify_forward_filter.msg | select('mapping') | list }}"
+    _forward_comments: "{{ _forward_filter_records | map(attribute='comment', default='') | list }}"
+    _default_drop_index: "{{ _forward_comments.index('DEFAULT DROP (managed: routeros role)') }}"
+  when: routeros_enable_default_drop | bool

--- a/terraform/network/main.tf
+++ b/terraform/network/main.tf
@@ -1,6 +1,6 @@
 # Required 1Password items (auth inherited via direnv):
 #   unifi_controller - Limited Admin (local-only) username/password
-#   unifi_wlan_psks  - section "WLAN", PSK fields: dflt, kds, gst, mgmt (mgmt: 24+ char random)
+#   unifi_wlan_psks  - section "WLAN", PSK fields: dflt, kds, gst
 data "onepassword_item" "unifi_controller" {
   vault = "5v7zjyz2kanfxgsui2jx735vum"
   title = "unifi_controller"

--- a/terraform/network/unifi.tf
+++ b/terraform/network/unifi.tf
@@ -7,12 +7,6 @@ data "unifi_client_qos_rate" "default" {
   name = var.unifi_user_group_name
 }
 
-# Native/untagged LAN (VLAN 1 = MGMT). MGMT SSID attaches here so clients land untagged
-# on VLAN 1 alongside the router, IPMI/BMC and controller. No RouterOS change needed.
-data "unifi_network" "mgmt" {
-  name = var.unifi_default_network_name
-}
-
 # third_party_gateway = the RB5009 owns L3/DHCP; the controller only tags the VLAN.
 resource "unifi_network" "vlan" {
   for_each = var.wireless_vlans
@@ -60,22 +54,6 @@ resource "unifi_wlan" "gst" {
   is_guest        = true
   l2_isolation    = true
   network_id      = unifi_network.vlan["gst"].id
-  ap_group_ids    = [data.unifi_ap_group.default.id]
-  user_group_id   = data.unifi_client_qos_rate.default.id
-}
-
-# MGMT — WPA3-only, hidden admin SSID on native VLAN 1 (router, IPMI/BMC, controller).
-# No l2_isolation: those are peer hosts on VLAN 1, isolation would block IPMI + controller.
-# wpa3_transition=false: no WPA2 downgrade path; security rests on WPA3-SAE + long PSK.
-resource "unifi_wlan" "mgmt" {
-  name            = "madviLANy-mgmt"
-  security        = "wpapsk"
-  passphrase      = local.psk["mgmt"].value
-  wpa3_support    = true
-  wpa3_transition = false
-  pmf_mode        = "required"
-  hide_ssid       = true
-  network_id      = data.unifi_network.mgmt.id
   ap_group_ids    = [data.unifi_ap_group.default.id]
   user_group_id   = data.unifi_client_qos_rate.default.id
 }

--- a/terraform/network/variables.tf
+++ b/terraform/network/variables.tf
@@ -15,12 +15,6 @@ variable "unifi_user_group_name" {
   default = "Default"
 }
 
-# Native LAN (VLAN 1) the MGMT SSID attaches to; a second untagged network is rejected. Override if renamed.
-variable "unifi_default_network_name" {
-  type    = string
-  default = "Default"
-}
-
 # Wireless VLANs only (MGMT/SRV/DMZ are wired — see the routeros role). `subnet` (gateway
 # CIDR on the RB5009) is required by the schema but not served by the controller.
 variable "wireless_vlans" {


### PR DESCRIPTION
## Summary
- remove the hidden UniFi MGMT SSID so management stays wired-only
- remove the now-unused native MGMT UniFi network lookup and default-network variable
- remove the broad MGMT/admin -> internal forward allow; routed access into SRV/DFLT/KDS/GST/DMZ now requires explicit future rules
- add the OOB port to the LAN interface list so defconf input filtering does not block recovery access, then explicitly drop OOB forwarded traffic so it remains router-only
- add read-only RouterOS verification checks for OOB/DMZ topology, LAN membership, DHCP interfaces, bridge vlan-filtering state, default-drop state, and unmanaged accepts above default-drop
- require an explicit default-drop tag when routeros_enable_default_drop=true, so default-drop cannot be enabled by merely setting the var in a broad run
- derive firewall policy object lists from named topology vars instead of repeating subnet/interface literals in the role
- document the verified Proxmox host bridge topology; vmbr1 has now been simplified live to an untagged DMZ bridge
- update RouterOS/UniFi comments to document wired MGMT plus OOB recovery as the admin paths

## Proxmox check
Checked live host with ssh root@proxmox:
- vmbr0 has 10.77.1.100/24, gateway 10.77.1.1, and uplinks through eno2
- vmbr1 uplinks through eno1, has no host IP, and now has VLAN filtering disabled
- UniFi controller LXC 103, TrueNAS 101, and docker-host 102 are on vmbr0
- ai-dev VMs 110/111 are on vmbr1, but they are still holding 10.77.1.x leases; the RouterOS DMZ gateway 10.77.99.1 was not reachable from the Proxmox host after the vmbr1 cleanup, so the DMZ cutover still needs RouterOS-side/live DHCP verification

## Verification
- terraform fmt -check -recursive terraform/network
- git diff --check HEAD~1..HEAD
- cd ansible && ansible-playbook run.yaml --syntax-check --vault-password-file .vaultpass

The new read-only routeros --tags verify run was attempted, but the RouterOS API at 10.77.1.1:8729 timed out from this execution environment before any checks ran. terraform validate was previously attempted, but local provider binaries failed Terraform plugin handshake before configuration validation.