### PR TITLE
Manage docker-host swap and storage housekeeping

### DIFF
--- a/ansible/group_vars/docker.yaml
+++ b/ansible/group_vars/docker.yaml
@@ -5,7 +5,7 @@ docker_users: "{{ username }}"
 
 swap_mode: file
 swap_size_gb: 4
-swap_swappiness: 60
+swap_swappiness: 10
 
 # enables the firewall rule letting the compose proxy bridge reach Tailscale
 firewall_docker_bridge_subnet: 172.20.1.0/24

--- a/ansible/roles/common/defaults/main.yaml
+++ b/ansible/roles/common/defaults/main.yaml
@@ -7,3 +7,6 @@ swap_swappiness: 60
 # zram-generator options (used when swap_mode == zram)
 zram_size: ram
 zram_compression: zstd
+
+# Bound persistent systemd journal growth.
+journald_system_max_use: 500M

--- a/ansible/roles/common/tasks/journald.yaml
+++ b/ansible/roles/common/tasks/journald.yaml
@@ -1,0 +1,27 @@
+---
+- name: ensure journald drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: ansible_service_mgr == 'systemd'
+
+- name: configure journald retention
+  ansible.builtin.copy:
+    dest: /etc/systemd/journald.conf.d/10-retention.conf
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Journal]
+      SystemMaxUse={{ journald_system_max_use }}
+  register: journald_retention
+  when: ansible_service_mgr == 'systemd'
+
+- name: restart journald after retention change
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+  when: ansible_service_mgr == 'systemd' and journald_retention.changed

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -7,6 +7,10 @@
   ansible.builtin.include_tasks:
     file: ssh.yaml
 
+- name: configure journald retention
+  ansible.builtin.include_tasks:
+    file: journald.yaml
+
 - name: configure swap
   ansible.builtin.include_tasks:
     file: swap.yaml

--- a/ansible/roles/docker/defaults/main.yaml
+++ b/ansible/roles/docker/defaults/main.yaml
@@ -1,0 +1,9 @@
+---
+docker_log_driver: json-file
+docker_log_max_size: 20m
+docker_log_max_file: 3
+
+docker_image_prune_enabled: true
+docker_image_prune_until: 168h
+docker_image_prune_calendar: weekly
+docker_image_prune_randomized_delay: 1h

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,4 +1,81 @@
 ---
+- name: ensure Docker daemon config directory exists
+  ansible.builtin.file:
+    path: /etc/docker
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: configure Docker daemon log rotation
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      {
+        "log-driver": "{{ docker_log_driver }}",
+        "log-opts": {
+          "max-size": "{{ docker_log_max_size }}",
+          "max-file": "{{ docker_log_max_file | string }}"
+        }
+      }
+  register: docker_daemon_config
+
+- name: apply Docker daemon config before compose changes
+  ansible.builtin.systemd:
+    name: docker
+    state: restarted
+  when: docker_daemon_config.changed
+
+- name: install Docker image prune service
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/docker-image-prune.service
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Prune unused Docker images
+      Wants=docker.service
+      After=docker.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/docker image prune -f --filter until={{ docker_image_prune_until }}
+  register: docker_image_prune_service
+
+- name: install Docker image prune timer
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/docker-image-prune.timer
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Run Docker image prune weekly
+
+      [Timer]
+      OnCalendar={{ docker_image_prune_calendar }}
+      Persistent=true
+      RandomizedDelaySec={{ docker_image_prune_randomized_delay }}
+
+      [Install]
+      WantedBy=timers.target
+  register: docker_image_prune_timer
+
+- name: reload systemd after Docker prune unit changes
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: docker_image_prune_service.changed or docker_image_prune_timer.changed
+
+- name: configure Docker image prune timer state
+  ansible.builtin.systemd:
+    name: docker-image-prune.timer
+    enabled: "{{ docker_image_prune_enabled }}"
+    state: "{{ 'started' if docker_image_prune_enabled else 'stopped' }}"
+
 - name: set clone directory
   ansible.builtin.set_fact:
     clone_dir: /tmp/home-infra


### PR DESCRIPTION
## Summary
- lower docker-host swappiness to 10 while retaining the existing 4G file swap
- manage Docker daemon json-file log rotation at 20m x 3 files
- add a weekly image-only prune timer with `docker image prune -f --filter until=168h`
- cap persistent journald usage with `SystemMaxUse=500M`

## Validation
- `ANSIBLE_LOCAL_TEMP=/private/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/.ansible/tmp ansible-playbook run.yaml --syntax-check --vault-password-file .vaultpass --limit docker-host`
- `git diff --check`

## Rollout notes
- applying the docker role will restart Docker if `/etc/docker/daemon.json` changes
- existing containers must be recreated to pick up daemon log rotation settings
- the existing docker role force-recreates the init compose stack during rollout