### PR TITLE
Fix Pocket ID encryption key rollout

### DIFF
--- a/ansible/roles/docker/defaults/main.yaml
+++ b/ansible/roles/docker/defaults/main.yaml
@@ -7,3 +7,6 @@ docker_image_prune_enabled: true
 docker_image_prune_until: 168h
 docker_image_prune_calendar: weekly
 docker_image_prune_randomized_delay: 1h
+
+pocket_id_encryption_key_dir: /etc/pocket-id
+pocket_id_encryption_key_path: "{{ pocket_id_encryption_key_dir }}/encryption-key"

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -114,11 +114,54 @@
     state: absent
   when: repo.stat.exists
 
+- name: ensure Pocket ID secret directory exists
+  ansible.builtin.file:
+    path: "{{ pocket_id_encryption_key_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+
+- name: check for Pocket ID encryption key
+  ansible.builtin.stat:
+    path: "{{ pocket_id_encryption_key_path }}"
+  register: pocket_id_key_file
+
+- name: generate Pocket ID encryption key
+  ansible.builtin.command:
+    cmd: openssl rand -hex 32
+  register: generated_pocket_id_key
+  changed_when: true
+  when: not pocket_id_key_file.stat.exists
+  no_log: true
+
+- name: persist Pocket ID encryption key
+  ansible.builtin.copy:
+    content: "{{ generated_pocket_id_key.stdout }}\n"
+    dest: "{{ pocket_id_encryption_key_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+  when: not pocket_id_key_file.stat.exists
+  no_log: true
+
+- name: read Pocket ID encryption key
+  ansible.builtin.slurp:
+    src: "{{ pocket_id_encryption_key_path }}"
+  register: pocket_id_key
+  no_log: true
+
+- name: set Pocket ID encryption key fact
+  ansible.builtin.set_fact:
+    pocket_id_encryption_key: "{{ pocket_id_key.content | b64decode | trim }}"
+  no_log: true
+
 - name: setup .env file
   ansible.builtin.copy:
     content: |
       CF_DNS_API_TOKEN={{ CF_DNS_API_TOKEN }}
       CF_API_EMAIL={{ CF_API_EMAIL }}
+      ENCRYPTION_KEY={{ pocket_id_encryption_key }}
       MAXMIND_LICENSE_KEY={{ MAXMIND_LICENSE_KEY }}
     dest: "{{ srv_dir }}/.env"
     owner: "{{ username }}"

--- a/docker/init/compose.yml
+++ b/docker/init/compose.yml
@@ -68,6 +68,7 @@ services:
     environment:
       - APP_URL=https://pocket-id.local.elmurphy.com
       - TRUST_PROXY=true
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
       - MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY}
       - PUID=1000
       - PGID=1000


### PR DESCRIPTION
## Summary
- pass `ENCRYPTION_KEY` into the Pocket ID init stack
- generate a stable host-local key at `/etc/pocket-id/encryption-key` when missing
- render that key into `/srv/init/.env` without storing secret material in git

## Validation
- `ANSIBLE_LOCAL_TEMP=/private/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/.ansible/tmp ansible-playbook run.yaml --syntax-check --vault-password-file .vaultpass --limit docker-host`
- `git diff --check`
- applied targeted repair on docker-host; `pocket-id` is running healthy

## Rollout notes
- `/etc/pocket-id/encryption-key` is `0600 root:root`
- future docker role runs will preserve and reuse the host-local key