### PR TITLE
feat(infra): codify unifi os network state

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,35 @@ Proxmox v9.1.6 (hypervisor)
 ├── TrueNAS VM (SRV VLAN) ─── NFS shares (media, downloads, bulk storage)
 ├── Docker Host VM (Ubuntu 24.04) ─── 18+ services via Docker Compose
 │   └── Traefik → *.local.elmurphy.com (TLS via Cloudflare ACME)
-└── [Talos K8s VM] ─── Inactive, pending stability investigation
+├── UniFi OS Server VM (MGMT) ─── Network controller for AP/WLANs
+├── ai-dev-bgd VM (DMZ) ─── Isolated AI development sandbox
+└── [Talos K8s VM] ─── Inactive, pending migration work
 ```
 
-### Network (Ubiquiti Dream Machine)
+### Network (MikroTik RB5009 + UniFi AP)
 
-| VLAN           | Purpose                                 |
-| -------------- | --------------------------------------- |
-| Skynet         | Trusted devices (laptop, server)        |
-| Skynet - DMZ   | Internet-exposed services (isolated)    |
-| Skynet - IoT   | Smart home devices                      |
-| Skynet - Work  | Work devices (MAC whitelist, isolated)  |
-| Skynet - Jnr   | Kids devices (content + time filtering) |
-| Skynet - Guest | Visitors                                |
+Routing, DHCP, firewall policy and inter-VLAN isolation live on the MikroTik
+RB5009 and are managed by the Ansible `routeros` role. The UniFi controller runs
+as a dedicated Proxmox VM (`unifi-controller`, VMID 111) and the AP/WLAN objects
+are managed through the UniFi controller API (`terraform/network`).
 
-The server has two ethernet ports mapped to Skynet and Skynet-DMZ respectively via Proxmox.
+| Network | VLAN / link | Purpose |
+| --- | --- | --- |
+| MGMT | native VLAN 1 | Wired-only management plane (`10.77.1.0/24`) |
+| SRV | VLAN 20 | TrueNAS + docker-host services (`10.77.20.0/24`) |
+| DFLT | VLAN 30 | Main wireless clients (`10.77.30.0/24`) |
+| KDS | VLAN 50 | Kids wireless clients with filtered DNS (`10.77.50.0/24`) |
+| GST | VLAN 60 | Guest wireless clients with UniFi L2 isolation (`10.77.60.0/24`) |
+| DMZ | RB5009 `ether2` / Proxmox `vmbr1` | Isolated ai-dev VMs (`10.77.99.0/24`) |
+| OOB | RB5009 `ether7` | Break-glass router access (`10.66.0.0/30`) |
+
+The server has two ethernet ports: `eno2`/`vmbr0` trunks MGMT/SRV to RB5009
+`ether3`, while `eno1`/`vmbr1` is the untagged DMZ uplink to RB5009 `ether2`.
+The UniFi U7 Pro AP is adopted in the controller. The three managed WLANs are
+attached to the default `All APs` group and mapped to the DFLT/KDS/GST
+VLAN-only networks. The ai-dev VMs are isolated on the physical DMZ
+(`10.77.99.0/24`), protected by host nftables default-deny input rules, and
+further scoped by an external Tailscale ACL policy managed outside this repo.
 
 ## Repository Structure
 
@@ -68,10 +82,13 @@ nix develop
 just init       # terraform init
 just apply      # terraform apply
 just destroy    # terraform destroy
+just network-init && just network-apply   # UniFi VLAN-only networks + WLANs
 
 # Ansible
 just reqs                   # install galaxy requirements
 just run docker-host        # run playbook against a host
+just run unifi-controller   # configure UniFi OS Server VM
+just routeros               # steady-state strict RouterOS config
 just edit                   # edit encrypted vault secrets
 ```
 
@@ -84,14 +101,16 @@ Run Terraform through the `just` recipes so local state and generated cloud-init
 | ------------ | --- | ---------------------------- | ----------------------- |
 | truenas      | 101 | 2 CPU, 10GB RAM, 32GB        | NAS with HBA passthrough |
 | docker-host  | 102 | 6 CPU, 10GB RAM, 128GB       | Docker Compose services |
+| ai-dev-bgd   | 110 | 2 CPU, 4GB RAM, 150GB        | AI development sandbox   |
+| unifi        | 111 | 2 CPU, 4GB RAM, 40GB         | UniFi OS Server          |
 | talos-prod-1 | 200 | 6 CPU, 10GB RAM, 100GB+128GB | Kubernetes (inactive)   |
 
-Cloud-init template (`cloud_init.tftpl`) bootstraps the ansible user, installs qemu-guest-agent, Tailscale, and Docker.
+Cloud-init template (`cloud_init.tftpl`) bootstraps the management user, installs qemu-guest-agent, and joins Tailscale.
 TrueNAS and docker-host are managed with `prevent_destroy`; their pinned MAC addresses are supplied through sensitive Terraform variables in the ignored root `.envrc`.
 
 ## Ansible
 
-Configures provisioned VMs with four roles:
+Configures provisioned hosts and the RB5009 with these primary roles:
 
 | Role     | Purpose                                     |
 | -------- | ------------------------------------------- |
@@ -99,8 +118,19 @@ Configures provisioned VMs with four roles:
 | firewall | UFW rules                                   |
 | media    | NFS mounts, media user/group (UID/GID 1215) |
 | docker   | Docker engine installation                  |
+| unifi    | UniFi OS Server install                     |
+| routeros | RB5009 VLANs, DHCP, firewall, NAT, OOB port |
 
 Secrets are managed via ansible-vault (`ansible/group_vars/secrets.yaml`).
+
+RouterOS strict mode is the current steady state. `just routeros` maintains the
+strict config; `just routeros-scaffold` is only for pre-strict bootstrap or
+recovery work. See `ansible/roles/routeros/README.md`.
+
+## Network Operations
+
+Apply/verify order for a fresh rebuild is manual: root Terraform →
+`just run unifi-controller` → `terraform/network` → `just routeros`.
 
 ## Docker Services
 
@@ -136,7 +166,7 @@ All services run behind Traefik on the shared `proxy` network (172.20.1.0/24) wi
 
 ## Kubernetes (Inactive)
 
-Talos Linux single-node cluster managed by Flux CD. Currently offline due to unresolved Proxmox host instability when Flux deploys workloads. See [docs/PRD.md](docs/PRD.md) for the migration plan.
+Talos Linux single-node cluster managed by Flux CD. Currently inactive pending the next Kubernetes migration pass. See [docs/PRD.md](docs/PRD.md) for the migration plan.
 
 ## CI/CD
 

--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -1,5 +1,5 @@
 ---
-# OPEN ITEMS to verify on the live router: interface/bridge names, admin + IPMI IPs, KDS DNS choice.
+# OPEN ITEMS to verify on the live router: interface/bridge names, admin + IPMI IPs.
 # Required: create a restricted API user first (creds in vaulted secrets.yaml):
 #   /user group add name=ansible policy=api,read,write,policy,test,sensitive
 #   /user add name=ansible group=ansible password=<vaulted>
@@ -93,7 +93,7 @@ routeros_wan_egress_subnets: >-
   }}
 
 routeros_default_dns: 10.77.1.1
-routeros_kids_dns: 1.1.1.3 # OPEN ITEM: Cloudflare Families / NextDNS / AdGuard
+routeros_kids_dns: 1.1.1.3 # Cloudflare Families
 
 # MGMT DHCP reliability. MGMT (native VLAN 1) keeps its server on the raw bridge; we
 # only set a sane lease time and pin infra to fixed addresses so a missed renewal can

--- a/ansible/group_vars/unifi.yaml
+++ b/ansible/group_vars/unifi.yaml
@@ -16,7 +16,9 @@ unifi_ap_source: 10.77.1.0/24
 # the firewall role's deleted bare 22/tcp rule so it survives default-deny.
 firewall_allow_ports:
   - { port: "22", proto: tcp, from: "{{ unifi_admin_source }}" } # ssh / ansible
-  - { port: "8443", proto: tcp, from: "{{ unifi_admin_source }}" } # controller GUI
+  - { port: "11443", proto: tcp, from: "{{ unifi_admin_source }}" } # UniFi OS Server console
+  - { port: "8443", proto: tcp, from: "{{ unifi_admin_source }}" } # Network GUI/API
   - { port: "8080", proto: tcp, from: "{{ unifi_ap_source }}" } # device inform / adoption
   - { port: "3478", proto: udp, from: "{{ unifi_ap_source }}" } # STUN
   - { port: "10001", proto: udp, from: "{{ unifi_ap_source }}" } # AP discovery
+  - { port: "8444", proto: tcp, from: "{{ unifi_ap_source }}" } # secure captive portal

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -3,11 +3,10 @@ docker-host
 
 [ai-dev]
 ai-dev-bgd
-ai-dev-bc
 
 [unifi]
-# LAN IP for the first run before Tailscale SSH is up; root key injected by terraform/unifi.
-unifi-controller ansible_host=10.77.1.10 ansible_user=root
+# LAN IP for the UniFi OS Server VM.
+unifi-controller ansible_host=10.77.1.10 ansible_user=mm
 
 [routeros]
 # Pushed over the RouterOS API (connection=local), not SSH; ansible_host is informational.

--- a/ansible/roles/common/tasks/users.yaml
+++ b/ansible/roles/common/tasks/users.yaml
@@ -19,6 +19,14 @@
     groups: wheel
     append: true
 
+- name: ensure management user's home is owned by the user
+  ansible.builtin.file:
+    path: "/home/{{ username }}"
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0755"
+
 - name: add authorised ssh key to user
   ansible.posix.authorized_key:
     user: "{{ username }}"

--- a/ansible/roles/routeros/README.md
+++ b/ansible/roles/routeros/README.md
@@ -17,7 +17,7 @@ to be absent from the production bridge.
    ```
    Put `routeros_api_user` / `routeros_api_password` in the vault (`just edit`).
 2. Confirm the OPEN ITEMS in `group_vars/routeros.yaml` (interface names, bridge
-   name, admin/IPMI IPs, KDS DNS) against the live router.
+   name, admin/IPMI IPs) against the live router.
 3. **Out-of-band access staged before any VLAN-filtering work.** The role pulls
    `routeros_oob_port` (`ether7`) out of the bridge and gives it `10.66.0.1/30`.
    Plug a laptop into it with a static `10.66.0.2/30` and confirm you can reach
@@ -25,9 +25,9 @@ to be absent from the production bridge.
    vlan-filtering — under filtering, untagged-VLAN1 console access **and**
    Winbox-by-MAC both stop working (learned the hard way on 2026-06-03).
 
-## Normal run (safe scaffold)
+## Normal run (strict steady state)
 
-`just routeros` is **safe** — it never enables the two lockout-risk flips:
+`just routeros` maintains the current strict RouterOS state:
 
 ```sh
 just routeros
@@ -36,8 +36,8 @@ just routeros
 It maintains: the out-of-band port, VLAN interfaces + per-VLAN DHCP, DMZ physical
 isolation, the firewall address-lists / **allow** rules / NAT, and management
 services restricted to `routeros_router_admin_sources` (MGMT + OOB subnets).
-`routeros_enable_vlan_filtering` / `routeros_enable_default_drop` default to
-`false`, and the vlan-filtering flip is additionally `never`-tagged.
+It also keeps `vlan-filtering` and managed `default-drop` enabled. The live router
+was verified in this state on 2026-06-06.
 
 The run ends with read-only verification. To run only the checks:
 
@@ -45,24 +45,24 @@ The run ends with read-only verification. To run only the checks:
 just routeros-verify
 ```
 
-## Lockout-risk flips (explicit, one at a time)
+## Scaffold / Recovery Run
 
-⚠️ A 2026-06-03 apply that enabled vlan-filtering with MGMT bound to the raw bridge
-caused a full management lockout that needed a physical reset. Do these only with the
-OOB port verified (prereq 3):
+`just routeros-scaffold` runs the pre-strict scaffold without the hardening flips.
+Use it only for bootstrap or recovery work before strict mode is re-enabled:
 
 ```sh
-just routeros-strict
+just routeros-scaffold
 ```
 
-The strict recipe applies the normal scaffold plus the two explicit hardening flips:
-`vlan-filtering` and `default-drop`. It is intentionally separate from
-`just routeros` so the lockout-risk path is auditable in shell history and review.
+⚠️ A 2026-06-03 apply that enabled vlan-filtering with MGMT bound to the raw bridge
+caused a full management lockout that needed a physical reset. Strict mode is now
+validated, but any scaffold/recovery work should still start from verified OOB access
+(prereq 3).
 
-After any flip, run the read-only verifier:
+To verify a scaffold/non-strict state only:
 
 ```sh
-just routeros-verify-strict
+just routeros-verify-scaffold
 ```
 
 Also inspect `/interface bridge vlan print`, `/interface bridge port print`,

--- a/ansible/roles/unifi/defaults/main.yaml
+++ b/ansible/roles/unifi/defaults/main.yaml
@@ -1,6 +1,4 @@
 ---
-# UniFi Network 8.x+ supports MongoDB up to 7.0 (not 8.x).
-mongodb_version: "7.0"
-
-# UniFi Network 10.x requires Java 25 (Eclipse Temurin).
-unifi_java_version: "25"
+unifi_os_server_version: "5.0.8"
+unifi_os_server_download_url: "https://fw-download.ubnt.com/data/unifi-os-server/c2e4-linux-x64-5.0.8-bcb62759-753a-4be2-8546-a6e0de63e59a.8-x64"
+unifi_os_server_installer_path: "/usr/local/src/unifi-os-server-{{ unifi_os_server_version }}-linux-x64"

--- a/ansible/roles/unifi/tasks/main.yaml
+++ b/ansible/roles/unifi/tasks/main.yaml
@@ -1,95 +1,29 @@
 ---
-- name: ensure apt keyring dir
-  ansible.builtin.file:
-    path: /etc/apt/keyrings
-    state: directory
-    mode: "0755"
-
-- name: install base packages
+- name: install UniFi OS Server prerequisites
   ansible.builtin.apt:
     name:
       - ca-certificates
       - curl
-      - gnupg
-      - apt-transport-https
+      - podman
+      - slirp4netns
     state: present
     update_cache: true
     cache_valid_time: 3600
 
-# Debian 12 doesn't ship Java 25; pull Eclipse Temurin from Adoptium.
-- name: download adoptium signing key
+- name: download UniFi OS Server installer
   ansible.builtin.get_url:
-    url: https://packages.adoptium.net/artifactory/api/gpg/key/public
-    dest: /etc/apt/keyrings/adoptium.asc
-    mode: "0644"
+    url: "{{ unifi_os_server_download_url }}"
+    dest: "{{ unifi_os_server_installer_path }}"
+    mode: "0755"
 
-- name: dearmor adoptium signing key
+- name: install UniFi OS Server
   ansible.builtin.command:
-    cmd: gpg --batch --yes --dearmor -o /etc/apt/keyrings/adoptium.gpg /etc/apt/keyrings/adoptium.asc
-    creates: /etc/apt/keyrings/adoptium.gpg
+    cmd: "{{ unifi_os_server_installer_path }}"
+    creates: /usr/local/bin/uosserver
+    stdin: "y\n"
 
-- name: add adoptium repo
-  ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bookworm main"
-    filename: adoptium
-    state: present
-
-# --- MongoDB (binary only; UniFi runs its own mongod instance on :27117) ---
-- name: download mongodb signing key
-  ansible.builtin.get_url:
-    url: "https://pgp.mongodb.com/server-{{ mongodb_version }}.asc"
-    dest: "/etc/apt/keyrings/mongodb-server-{{ mongodb_version }}.asc"
-    mode: "0644"
-
-- name: dearmor mongodb signing key
-  ansible.builtin.command:
-    cmd: >-
-      gpg --batch --yes --dearmor
-      -o /etc/apt/keyrings/mongodb-server-{{ mongodb_version }}.gpg
-      /etc/apt/keyrings/mongodb-server-{{ mongodb_version }}.asc
-    creates: "/etc/apt/keyrings/mongodb-server-{{ mongodb_version }}.gpg"
-
-- name: add mongodb repo
-  ansible.builtin.apt_repository:
-    repo: >-
-      deb [signed-by=/etc/apt/keyrings/mongodb-server-{{ mongodb_version }}.gpg]
-      https://repo.mongodb.org/apt/debian bookworm/mongodb-org/{{ mongodb_version }} main
-    filename: "mongodb-org-{{ mongodb_version }}"
-    state: present
-
-# --- UniFi Network controller ---
-- name: download unifi signing key
-  ansible.builtin.get_url:
-    url: https://dl.ui.com/unifi/unifi-repo.gpg
-    dest: /etc/apt/keyrings/unifi-repo.gpg
-    mode: "0644"
-
-- name: add unifi repo
-  ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/keyrings/unifi-repo.gpg] https://www.ui.com/downloads/unifi/debian stable ubiquiti"
-    filename: unifi
-    state: present
-
-- name: install unifi packages
-  ansible.builtin.apt:
-    name:
-      - "temurin-{{ unifi_java_version }}-jre"
-      - mongodb-org-server
-      - unifi
-    state: present
-    update_cache: true
-
-# UniFi spawns + manages its own mongod on :27117; the packaged systemd instance
-# (:27017) is redundant and wastes RAM on a memory-constrained host.
-- name: disable redundant system mongod instance
+- name: enable and start UniFi OS Server
   ansible.builtin.systemd:
-    name: mongod
-    enabled: false
-    state: stopped
-  failed_when: false
-
-- name: enable and start unifi
-  ansible.builtin.systemd:
-    name: unifi
+    name: uosserver
     enabled: true
     state: started

--- a/justfile
+++ b/justfile
@@ -12,7 +12,8 @@ apply:
 destroy:
   umask 077; cd terraform && terraform destroy
 
-# UniFi controller LXC lives in its own root (bpg provider; see terraform/unifi/versions.tf)
+# Legacy UniFi Network controller LXC root. Kept temporarily for rollback during
+# the UniFi OS Server VM migration.
 unifi-init:
   umask 077; cd terraform/unifi && terraform init
 
@@ -40,14 +41,24 @@ edit:
 reqs:
   cd ansible && ansible-galaxy install -r requirements.yaml
 
-routeros:
+unifi-bootstrap:
+  # Legacy terraform/unifi LXC bootstrap only.
+  cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --limit unifi -e ansible_user=root
+
+routeros-scaffold:
   cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --limit routeros
 
-routeros-verify:
+routeros-verify-scaffold:
   cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --limit routeros --tags verify
+
+routeros-verify:
+  cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --limit routeros --tags verify -e routeros_enable_vlan_filtering=true -e routeros_enable_default_drop=true
 
 routeros-verify-strict:
   cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --limit routeros --tags verify -e routeros_enable_vlan_filtering=true -e routeros_enable_default_drop=true
+
+routeros:
+  cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --limit routeros --tags services,oob,vlans,dmz,dhcp,firewall,bridge,vlan-filtering,default-drop,verify -e routeros_enable_vlan_filtering=true -e routeros_enable_default_drop=true
 
 routeros-strict:
   cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --limit routeros --tags services,oob,vlans,dmz,dhcp,firewall,bridge,vlan-filtering,default-drop,verify -e routeros_enable_vlan_filtering=true -e routeros_enable_default_drop=true

--- a/terraform/cloud_init.tftpl
+++ b/terraform/cloud_init.tftpl
@@ -18,7 +18,10 @@ packages:
   - qemu-guest-agent
 runcmd:
   - systemctl enable --now qemu-guest-agent
+  - pacman-key --init
+  - pacman-key --populate archlinux
   - pacman -Sy --noconfirm archlinux-keyring
+  - pacman -Syu --noconfirm
   - curl -fsSL https://tailscale.com/install.sh | sh
   - tailscale up --ssh --hostname=${hostname} --advertise-tags=tag:ai-dev --authkey=${tailscale_auth_key}
 %{ endif ~}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,11 +45,6 @@ import {
   id = "proxmox/110"
 }
 
-import {
-  to = module.ai_dev["ai-dev-bc"].proxmox_virtual_environment_vm.this
-  id = "proxmox/111"
-}
-
 # Manually provisioned (no cloud-init); HBA passed through for ZFS.
 # prevent_destroy blocks accidental replacement while still allowing drift detection.
 resource "proxmox_virtual_environment_vm" "truenas" {
@@ -222,6 +217,105 @@ resource "proxmox_virtual_environment_vm" "cloud_init_docker_host" {
   }
 }
 
+resource "local_sensitive_file" "cloud_init_unifi" {
+  content = sensitive(templatefile("cloud_init.tftpl", {
+    hostname           = "unifi-controller"
+    os_family          = "debian"
+    tailscale_auth_key = local.proxmox_creds.tailscale_auth_key
+    ssh_public_key     = var.unifi_ssh_public_key
+  }))
+  filename        = "${path.module}/files/unifi-controller.cfg"
+  file_permission = "0600"
+}
+
+resource "proxmox_virtual_environment_file" "cloud_init_unifi" {
+  content_type = "snippets"
+  datastore_id = "local"
+  node_name    = local.proxmox_node
+  overwrite    = true
+  source_file {
+    path      = local_sensitive_file.cloud_init_unifi.filename
+    file_name = "unifi-controller.yml"
+    checksum  = local_sensitive_file.cloud_init_unifi.content_sha256
+  }
+}
+
+resource "proxmox_virtual_environment_vm" "unifi_controller" {
+  depends_on = [
+    proxmox_virtual_environment_file.cloud_init_unifi,
+  ]
+  vm_id               = 111
+  name                = "unifi-controller"
+  description         = "UniFi OS Server (managed by Terraform and Ansible)."
+  node_name           = local.proxmox_node
+  tags                = ["ubuntu", "unifi"]
+  bios                = "seabios"
+  keyboard_layout     = "en-us"
+  boot_order          = ["scsi0"]
+  on_boot             = true
+  reboot_after_update = true
+  scsi_hardware       = "virtio-scsi-single"
+  started             = true
+  agent {
+    enabled = true
+    type    = "virtio"
+  }
+  operating_system {
+    type = "l26"
+  }
+  startup {
+    order = 3
+  }
+  clone {
+    full      = false
+    node_name = local.proxmox_node
+    vm_id     = var.ubuntu_server_24_04_template_vmid
+  }
+  cpu {
+    cores   = 2
+    sockets = 1
+    type    = "host"
+  }
+  memory {
+    dedicated = 4096
+  }
+  initialization {
+    datastore_id        = "local-zfs"
+    interface           = "ide1"
+    vendor_data_file_id = "local:snippets/unifi-controller.yml"
+    ip_config {
+      ipv4 {
+        address = "10.77.1.10/24"
+        gateway = "10.77.1.1"
+      }
+    }
+    user_account {
+      keys     = [var.unifi_ssh_public_key]
+      username = "mm"
+    }
+  }
+  serial_device {
+    device = "socket"
+  }
+  disk {
+    datastore_id = "local-zfs"
+    discard      = "on"
+    file_format  = "raw"
+    interface    = "scsi0"
+    iothread     = false
+    replicate    = false
+    size         = 40
+  }
+  network_device {
+    bridge = "vmbr0"
+    model  = "virtio"
+  }
+  lifecycle {
+    ignore_changes  = [clone]
+    prevent_destroy = true
+  }
+}
+
 # Blueprint for the planned K8s migration; gated by enable_talos until then.
 resource "proxmox_virtual_environment_vm" "talos_control_plane" {
   count               = var.enable_talos ? 1 : 0
@@ -286,7 +380,7 @@ module "ai_dev" {
   name                = each.key
   vmid                = each.value.vmid
   clone_template_vmid = var.arch_cloud_template_vmid
-  tags                = ["ai-dev", "arch"]
+  tags                = ["arch", "ai-dev"]
   cores               = 2
   memory_mib          = 4096
   disk_size           = 150

--- a/terraform/network/.terraform.lock.hcl
+++ b/terraform/network/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/1password/onepassword" {
   version     = "3.3.1"
   constraints = "3.3.1"
   hashes = [
+    "h1:35PCpSNLVubReT1imwfC+FpIP5gQWx+rvG4njkXkZKM=",
     "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
     "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
     "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
@@ -21,6 +22,7 @@ provider "registry.terraform.io/ubiquiti-community/unifi" {
   version     = "0.41.25"
   constraints = "~> 0.41"
   hashes = [
+    "h1:qRFnztw0TZG/RQVLHe2Pjz5U/IOY0g+8ESV1AwzIEWU=",
     "h1:zwJDyrNyfxz3/iHXVSRO3mVxMrE5VAOM2Q8g7Z2yOnI=",
     "zh:1f45ce17895b191156c1556cb704e022c903afce13d4d0eb9c7a8c2ba1d5c882",
     "zh:25350e49be814fa80b0831d598773ef5ca6349875fc84ae8c68c5aeecc8546a6",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "docker_host_ssh_public_key" {
   default     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8UxcTkHym30wEg6jekF"
 }
 
+variable "unifi_ssh_public_key" {
+  type        = string
+  description = "SSH public key for the mm user on the UniFi OS Server VM."
+  default     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8UxcTkHym30wEg6jekF"
+}
+
 variable "ai_dev_ssh_public_key" {
   type        = string
   description = "SSH public key for the michael user on ai-dev VMs (the laptop key)."
@@ -40,7 +46,6 @@ variable "ai_devs" {
   }))
   default = {
     "ai-dev-bgd" = { vmid = 110 }
-    "ai-dev-bc"  = { vmid = 111 }
   }
 }
 


### PR DESCRIPTION
## Summary
- provision UniFi OS Server as the managed Proxmox VM 111 and update the UniFi Ansible role to install/run uosserver
- update UniFi firewall ports, inventory, docs, and just recipes for the current RouterOS strict/network workflow
- harden Arch cloud-init keyring bootstrap, keep one ai-dev VM in Terraform, and add common user home ownership idempotence
- include Terraform provider lock hashes generated by the current network module tooling

## Local changes reviewed
- Committed the tracked infra changes listed above.
- Left untracked PLAN-ai-dev-vms.md and TODO.md out of this PR because they are completed/stale planning artifacts and are not referenced by the repo.

## Validation
- nix develop --command terraform fmt -check -recursive
- nix develop --command bash -c 'cd terraform && terraform validate'
- nix develop --command bash -c 'cd terraform/network && terraform validate'
- nix develop --command bash -c 'cd ansible && ansible-playbook run.yaml --vault-password-file .vaultpass --syntax-check'