### PR TITLE
feat(unifi): add Sonos WLAN compatibility

### DIFF
--- a/terraform/network/main.tf
+++ b/terraform/network/main.tf
@@ -1,6 +1,7 @@
 # Required 1Password items (auth inherited via direnv):
 #   unifi_controller - Limited Admin (local-only) username/password
 #   unifi_wlan_psks  - section "WLAN", PSK fields: dflt, kds, gst
+#                      optional: sonos, then set var.sonos_wlan_psk_field
 data "onepassword_item" "unifi_controller" {
   vault = "5v7zjyz2kanfxgsui2jx735vum"
   title = "unifi_controller"

--- a/terraform/network/unifi.tf
+++ b/terraform/network/unifi.tf
@@ -7,6 +7,13 @@ data "unifi_client_qos_rate" "default" {
   name = var.unifi_user_group_name
 }
 
+resource "unifi_setting" "mgmt" {
+  mgmt = {
+    auto_upgrade = true
+    ssh_enabled  = false
+  }
+}
+
 moved {
   from = unifi_wlan.main
   to   = unifi_wlan.dflt
@@ -40,6 +47,11 @@ resource "unifi_wlan" "dflt" {
   wpa3_transition = true
   pmf_mode        = "optional"
   bss_transition  = true
+  iapp_enabled    = true
+  group_rekey     = 0
+  dtim_6e         = 3
+  dtim_na         = 3
+  dtim_ng         = 1
 
   minimum_data_rate_2g_kbps = 1000
   minimum_data_rate_5g_kbps = 6000
@@ -63,6 +75,11 @@ resource "unifi_wlan" "kds" {
   wpa3_transition = false
   pmf_mode        = "required"
   bss_transition  = true
+  iapp_enabled    = true
+  group_rekey     = 0
+  dtim_6e         = 3
+  dtim_na         = 3
+  dtim_ng         = 1
 
   minimum_data_rate_2g_kbps = 1000
   minimum_data_rate_5g_kbps = 6000
@@ -86,6 +103,11 @@ resource "unifi_wlan" "gst" {
   wpa3_transition = true
   pmf_mode        = "optional"
   bss_transition  = true
+  iapp_enabled    = true
+  group_rekey     = 0
+  dtim_6e         = 3
+  dtim_na         = 3
+  dtim_ng         = 1
 
   minimum_data_rate_2g_kbps = 1000
   minimum_data_rate_5g_kbps = 6000
@@ -102,16 +124,32 @@ resource "unifi_wlan" "gst" {
   user_group_id = data.unifi_client_qos_rate.default.id
 }
 
-# Fallback if a legacy Sonos won't join WPA3: uncomment, add a `sonos` PSK field (DFLT keeps mDNS native).
-# resource "unifi_wlan" "sonos" {
-#   name            = "madviLANy-sonos"
-#   security        = "wpapsk"
-#   passphrase      = local.psk["sonos"].value
-#   wpa3_support    = false
-#   wpa3_transition = false
-#   pmf_mode        = "disabled"
-#   wlan_band       = "2g"
-#   network_id      = unifi_network.vlan["dflt"].id
-#   ap_group_ids    = [data.unifi_ap_group.default.id]
-#   user_group_id   = data.unifi_client_qos_rate.default.id
-# }
+# Sonos legacy compatibility. Stays on DFLT so discovery/mDNS remains native.
+resource "unifi_wlan" "sonos" {
+  name                       = "madviLANy-sonos"
+  security                   = "wpapsk"
+  passphrase                 = local.psk[var.sonos_wlan_psk_field].value
+  wpa3_support               = false
+  wpa3_transition            = false
+  pmf_mode                   = "disabled"
+  iapp_enabled               = true
+  group_rekey                = 3600
+  dtim_6e                    = 3
+  dtim_na                    = 3
+  dtim_ng                    = 1
+  wlan_band                  = "both"
+  wlan_bands                 = ["2g", "5g"]
+  no2ghz_oui                 = false
+  minrate_setting_preference = "auto"
+  minimum_data_rate_2g_kbps  = 1000
+  minimum_data_rate_5g_kbps  = 6000
+
+  mac_filter = {
+    enabled = false
+    policy  = "allow"
+  }
+
+  network_id    = unifi_network.vlan["dflt"].id
+  ap_group_ids  = [data.unifi_ap_group.default.id]
+  user_group_id = data.unifi_client_qos_rate.default.id
+}

--- a/terraform/network/variables.tf
+++ b/terraform/network/variables.tf
@@ -1,7 +1,7 @@
 variable "unifi_api_url" {
   type        = string
-  description = "UniFi Network controller API URL (LAN). Do NOT include the /api path; the SDK discovers it."
-  default     = "https://10.77.1.10:8443"
+  description = "UniFi OS Server URL (LAN). Do NOT include the /api path; the SDK discovers the Network API path."
+  default     = "https://10.77.1.10:11443"
 }
 
 # Controller defaults the SSIDs attach to; override if labelled differently (Settings -> WiFi).
@@ -13,6 +13,12 @@ variable "unifi_ap_group_name" {
 variable "unifi_user_group_name" {
   type    = string
   default = "Default"
+}
+
+variable "sonos_wlan_psk_field" {
+  type        = string
+  description = "1Password WLAN field used for the Sonos SSID PSK. Defaults to dflt until a dedicated sonos field exists."
+  default     = "dflt"
 }
 
 # Wireless VLANs only (MGMT/SRV/DMZ are wired — see the routeros role). `subnet` (gateway


### PR DESCRIPTION
## Summary
- add UniFi management settings and WLAN tuning defaults
- add active Sonos compatibility SSID on DFLT with configurable 1Password PSK field
- update UniFi OS Server URL default

## Validation
- git diff --check
- terraform -chdir=terraform/network fmt -check
- terraform -chdir=terraform/network validate (failed: local provider plugins failed schema startup)