### PR TITLE
ci: add path-scoped quality gates

### DIFF
--- a/.github/workflows/_quality-gate.yaml
+++ b/.github/workflows/_quality-gate.yaml
@@ -1,0 +1,80 @@
+name: Quality Gate Template
+
+on:
+  workflow_call:
+    inputs:
+      check:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  static:
+    name: ${{ inputs.check }}
+    runs-on: ubuntu-latest
+    env:
+      ADMIN_PASSWORD: ci-placeholder
+      ADMIN_USERNAME: ci-placeholder
+      CF_API_EMAIL: ci@example.invalid
+      CF_DNS_API_TOKEN: ci-placeholder
+      COUCHDB_PASSWORD: ci-placeholder
+      DATABASE_PASSWORD: ci-placeholder
+      DB_DATABASE_NAME: immich
+      DB_DATA_LOCATION: /tmp/immich-db
+      DB_PASSWORD: ci-placeholder
+      DB_USERNAME: immich
+      ENCRYPTION_KEY: ci-placeholder
+      MAXMIND_LICENSE_KEY: ci-placeholder
+      OWNCLOUD_DB_PASSWORD: ci-placeholder
+      PLEX_CLAIM: ci-placeholder
+      TF_IN_AUTOMATION: "true"
+      TZ: Australia/Melbourne
+      UPLOAD_LOCATION: /tmp/immich-upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+      - name: Check flake
+        if: inputs.check == 'nix'
+        run: nix flake check
+      - name: Lint workflows
+        if: inputs.check == 'actions'
+        run: nix develop --command actionlint
+      - name: Check Terraform formatting
+        if: inputs.check == 'terraform'
+        run: nix develop --command terraform -chdir=terraform fmt -check -recursive
+      - name: Validate Terraform roots
+        if: inputs.check == 'terraform'
+        run: |
+          nix develop --command bash -euo pipefail <<'SCRIPT'
+          for dir in terraform terraform/network; do
+            echo "Validating ${dir}"
+            terraform -chdir="${dir}" init -backend=false -input=false -lockfile=readonly
+            terraform -chdir="${dir}" validate
+          done
+          SCRIPT
+      - name: Render Compose files
+        if: inputs.check == 'docker'
+        run: |
+          nix develop --command bash -euo pipefail <<'SCRIPT'
+          while IFS= read -r compose_file; do
+            echo "Checking ${compose_file}"
+            docker-compose -f "${compose_file}" config --quiet
+          done < <(find docker -name compose.yml -print | sort)
+          SCRIPT
+      - name: Build and validate active kustomizations
+        if: inputs.check == 'kubernetes'
+        run: |
+          nix develop --command bash -euo pipefail <<'SCRIPT'
+          while IFS= read -r kustomization; do
+            dir="${kustomization%/*}"
+            echo "Checking ${dir}"
+            kubectl kustomize "${dir}" | kubeconform -summary -strict -ignore-missing-schemas
+          done < <(find kubernetes -path kubernetes/archive -prune -o -name kustomization.yaml -print | sort)
+          SCRIPT
+      - name: Parse Talos YAML
+        if: inputs.check == 'talos'
+        run: nix develop --command yq eval 'true' talos/controlplane-patch.yaml talos/schematic.yaml

--- a/.github/workflows/_quality-gate.yaml
+++ b/.github/workflows/_quality-gate.yaml
@@ -27,7 +27,7 @@ jobs:
         run: nix develop --command actionlint
       - name: Check Terraform formatting
         if: inputs.check == 'terraform'
-        run: nix develop --command terraform -chdir=terraform fmt -check -recursive
+        run: nix develop --command terraform-ci -chdir=terraform fmt -check -recursive
       - name: Validate Terraform roots
         if: inputs.check == 'terraform'
         env:
@@ -36,8 +36,8 @@ jobs:
           nix develop --command bash -euo pipefail <<'SCRIPT'
           for dir in terraform terraform/network; do
             echo "Validating ${dir}"
-            terraform -chdir="${dir}" init -backend=false -input=false -lockfile=readonly
-            terraform -chdir="${dir}" validate
+            terraform-ci -chdir="${dir}" init -backend=false -input=false -lockfile=readonly
+            terraform-ci -chdir="${dir}" validate
           done
           SCRIPT
       - name: Render Compose files

--- a/.github/workflows/_quality-gate.yaml
+++ b/.github/workflows/_quality-gate.yaml
@@ -14,24 +14,6 @@ jobs:
   static:
     name: ${{ inputs.check }}
     runs-on: ubuntu-latest
-    env:
-      ADMIN_PASSWORD: ci-placeholder
-      ADMIN_USERNAME: ci-placeholder
-      CF_API_EMAIL: ci@example.invalid
-      CF_DNS_API_TOKEN: ci-placeholder
-      COUCHDB_PASSWORD: ci-placeholder
-      DATABASE_PASSWORD: ci-placeholder
-      DB_DATABASE_NAME: immich
-      DB_DATA_LOCATION: /tmp/immich-db
-      DB_PASSWORD: ci-placeholder
-      DB_USERNAME: immich
-      ENCRYPTION_KEY: ci-placeholder
-      MAXMIND_LICENSE_KEY: ci-placeholder
-      OWNCLOUD_DB_PASSWORD: ci-placeholder
-      PLEX_CLAIM: ci-placeholder
-      TF_IN_AUTOMATION: "true"
-      TZ: Australia/Melbourne
-      UPLOAD_LOCATION: /tmp/immich-upload
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -48,6 +30,8 @@ jobs:
         run: nix develop --command terraform -chdir=terraform fmt -check -recursive
       - name: Validate Terraform roots
         if: inputs.check == 'terraform'
+        env:
+          TF_IN_AUTOMATION: "true"
         run: |
           nix develop --command bash -euo pipefail <<'SCRIPT'
           for dir in terraform terraform/network; do
@@ -58,6 +42,23 @@ jobs:
           SCRIPT
       - name: Render Compose files
         if: inputs.check == 'docker'
+        env:
+          ADMIN_PASSWORD: ci-placeholder
+          ADMIN_USERNAME: ci-placeholder
+          CF_API_EMAIL: ci@example.invalid
+          CF_DNS_API_TOKEN: ci-placeholder
+          COUCHDB_PASSWORD: ci-placeholder
+          DATABASE_PASSWORD: ci-placeholder
+          DB_DATABASE_NAME: immich
+          DB_DATA_LOCATION: /tmp/immich-db
+          DB_PASSWORD: ci-placeholder
+          DB_USERNAME: immich
+          ENCRYPTION_KEY: ci-placeholder
+          MAXMIND_LICENSE_KEY: ci-placeholder
+          OWNCLOUD_DB_PASSWORD: ci-placeholder
+          PLEX_CLAIM: ci-placeholder
+          TZ: Australia/Melbourne
+          UPLOAD_LOCATION: /tmp/immich-upload
         run: |
           nix develop --command bash -euo pipefail <<'SCRIPT'
           while IFS= read -r compose_file; do

--- a/.github/workflows/_quality-gate.yaml
+++ b/.github/workflows/_quality-gate.yaml
@@ -24,16 +24,16 @@ jobs:
         run: nix flake check
       - name: Lint workflows
         if: inputs.check == 'actions'
-        run: nix develop --command actionlint
+        run: nix shell .#actionlint --command actionlint
       - name: Check Terraform formatting
         if: inputs.check == 'terraform'
-        run: nix develop --command terraform-ci -chdir=terraform fmt -check -recursive
+        run: nix shell .#terraform-ci --command terraform-ci -chdir=terraform fmt -check -recursive
       - name: Validate Terraform roots
         if: inputs.check == 'terraform'
         env:
           TF_IN_AUTOMATION: "true"
         run: |
-          nix develop --command bash -euo pipefail <<'SCRIPT'
+          nix shell .#terraform-ci --command bash -euo pipefail <<'SCRIPT'
           for dir in terraform terraform/network; do
             echo "Validating ${dir}"
             terraform-ci -chdir="${dir}" init -backend=false -input=false -lockfile=readonly
@@ -60,7 +60,7 @@ jobs:
           TZ: Australia/Melbourne
           UPLOAD_LOCATION: /tmp/immich-upload
         run: |
-          nix develop --command bash -euo pipefail <<'SCRIPT'
+          nix shell .#docker-compose --command bash -euo pipefail <<'SCRIPT'
           while IFS= read -r compose_file; do
             echo "Checking ${compose_file}"
             docker-compose -f "${compose_file}" config --quiet
@@ -69,7 +69,7 @@ jobs:
       - name: Build and validate active kustomizations
         if: inputs.check == 'kubernetes'
         run: |
-          nix develop --command bash -euo pipefail <<'SCRIPT'
+          nix shell .#kubectl .#kubeconform --command bash -euo pipefail <<'SCRIPT'
           while IFS= read -r kustomization; do
             dir="${kustomization%/*}"
             echo "Checking ${dir}"
@@ -78,4 +78,4 @@ jobs:
           SCRIPT
       - name: Parse Talos YAML
         if: inputs.check == 'talos'
-        run: nix develop --command yq eval 'true' talos/controlplane-patch.yaml talos/schematic.yaml
+        run: nix shell .#yq-go --command yq eval 'true' talos/controlplane-patch.yaml talos/schematic.yaml

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,27 @@
+name: Actions
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actions:
+    uses: ./.github/workflows/_quality-gate.yaml
+    with:
+      check: actions

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,31 @@
+name: Docker
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docker/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/docker.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docker/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/docker.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    uses: ./.github/workflows/_quality-gate.yaml
+    with:
+      check: docker

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -1,0 +1,31 @@
+name: Kubernetes
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "kubernetes/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/kubernetes.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "kubernetes/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/kubernetes.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kubernetes:
+    uses: ./.github/workflows/_quality-gate.yaml
+    with:
+      check: kubernetes

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,33 @@
+name: Nix
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "flake.lock"
+      - "flake.nix"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/nix.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "flake.lock"
+      - "flake.nix"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/nix.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix:
+    uses: ./.github/workflows/_quality-gate.yaml
+    with:
+      check: nix

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - ".github/renovate-config.json"
+      - "renovate.json"
   workflow_dispatch:
 
 permissions:
@@ -16,5 +19,5 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Validate repository config
         run: npx --yes --package renovate renovate-config-validator --strict
-      - name: Validate self-hosted config
+      - name: Validate Renovate bot config
         run: npx --yes --package renovate renovate-config-validator --strict .github/renovate-config.json

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -11,6 +11,11 @@ on:
     - cron: "30 4,6 * * *"
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Self-hosted Renovate
+      - name: Run Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         env:
           RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}

--- a/.github/workflows/talos.yaml
+++ b/.github/workflows/talos.yaml
@@ -1,0 +1,31 @@
+name: Talos
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "talos/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/talos.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "talos/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/talos.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  talos:
+    uses: ./.github/workflows/_quality-gate.yaml
+    with:
+      check: talos

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,31 @@
+name: Terraform
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/terraform.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/_quality-gate.yaml"
+      - ".github/workflows/terraform.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  terraform:
+    uses: ./.github/workflows/_quality-gate.yaml
+    with:
+      check: terraform

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Actions Runner Controller Test
+name: GitHub Runner Test
 on:
   workflow_dispatch:
 
@@ -6,7 +6,7 @@ permissions:
   contents: read
 
 jobs:
-  test-actions-runner:
-    runs-on: home-infra-runner
+  test-github-runner:
+    runs-on: ubuntu-latest
     steps:
-    - run: echo "🎉 This job uses runner scale set runners!"
+      - run: echo "GitHub-hosted runner is available."

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-github-runner:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -168,7 +168,15 @@ Talos Linux single-node cluster managed by Flux CD. Currently inactive pending t
 
 ## CI/CD
 
+- **Quality Gates**: Path-scoped static validation on PRs and pushes
+  - Actions workflow linting for `.github/workflows/**`
+  - Nix flake check for `flake.nix` and `flake.lock`
+  - Terraform format and validate for `terraform/**`
+  - Docker Compose render checks for `docker/**`
+  - Offline Kubernetes kustomize builds with kubeconform schema validation for `kubernetes/**`
+  - Talos YAML parsing for `talos/**`
 - **Renovate**: Automated dependency updates on schedule (GitHub Actions)
+  - Config validation only runs when Renovate config changes
   - Semantic commits with `actions-renovate/` branch prefix
   - Auto-merge for minor/patch (non-zero versions)
   - Custom versioning for Linuxserver.io images

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
     forAllSystems = f:
       nixpkgs.lib.genAttrs allSystems (system:
         f {
+          inherit system;
           pkgs = import nixpkgs {
             inherit system;
             config = {allowUnfree = true;};
@@ -46,11 +47,23 @@
         exec ${pkgs.terraform}/bin/terraform "$@"
       '';
   in {
-    devShells = forAllSystems ({pkgs}: {
+    packages = forAllSystems ({pkgs, ...}: {
+      actionlint = pkgs.actionlint;
+      docker-compose = pkgs.docker-compose;
+      kubectl = pkgs.kubectl;
+      kubeconform = pkgs.kubeconform;
+      terraform-ci = terraformCiFor pkgs;
+      yq-go = pkgs.yq-go;
+    });
+
+    devShells = forAllSystems ({
+      pkgs,
+      system,
+    }: {
       default = pkgs.mkShell {
         packages = [
           (terraformFor pkgs)
-          (terraformCiFor pkgs)
+          self.packages.${system}.terraform-ci
           # Ansible + librouteros on one interpreter: the community.routeros API
           # modules import librouteros from the controller's python (this shell).
           # ansible-core supplies the ansible-playbook CLI (the ansible bundle
@@ -63,10 +76,10 @@
           pkgs.fluxcd
           pkgs.kubernetes-helm
           pkgs.alejandra
-          pkgs.actionlint
-          pkgs.docker-compose
-          pkgs.kubeconform
-          pkgs.yq-go
+          self.packages.${system}.actionlint
+          self.packages.${system}.docker-compose
+          self.packages.${system}.kubeconform
+          self.packages.${system}.yq-go
         ];
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,10 @@
           pkgs.fluxcd
           pkgs.kubernetes-helm
           pkgs.alejandra
+          pkgs.actionlint
+          pkgs.docker-compose
+          pkgs.kubeconform
+          pkgs.yq-go
         ];
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -38,11 +38,19 @@
           runScript = "terraform";
         }
       else pkgs.terraform;
+
+    # GitHub-hosted Ubuntu runners do not allow the user namespace setup that
+    # buildFHSEnv uses, but CI only needs Terraform init/validate on glibc Linux.
+    terraformCiFor = pkgs:
+      pkgs.writeShellScriptBin "terraform-ci" ''
+        exec ${pkgs.terraform}/bin/terraform "$@"
+      '';
   in {
     devShells = forAllSystems ({pkgs}: {
       default = pkgs.mkShell {
         packages = [
           (terraformFor pkgs)
+          (terraformCiFor pkgs)
           # Ansible + librouteros on one interpreter: the community.routeros API
           # modules import librouteros from the controller's python (this shell).
           # ansible-core supplies the ansible-playbook CLI (the ansible bundle

--- a/kubernetes/apps/default/linkding/deployment.yaml
+++ b/kubernetes/apps/default/linkding/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: linkding
@@ -13,8 +15,6 @@ spec:
       labels:
         app: linkding
     spec:
-      strategy:
-        type: Recreate
       securityContext:
         runAsUser: 33
         runAsGroup: 33
@@ -53,7 +53,7 @@ spec:
             timeoutSeconds: 1
             failureThreshold: 3
           securityContext:
-            allowPriviligeEscalation: false
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/terraform/network/.terraform.lock.hcl
+++ b/terraform/network/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/1password/onepassword" {
   version     = "3.3.1"
   constraints = "3.3.1"
   hashes = [
+    "h1:35PCpSNLVubReT1imwfC+FpIP5gQWx+rvG4njkXkZKM=",
     "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
     "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
     "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",


### PR DESCRIPTION
## Summary
- split static CI into path-scoped domain workflows backed by a reusable quality-gate workflow
- keep all actions on GitHub-hosted runners and offline/static for inactive Kubernetes/Talos infrastructure
- scope Renovate config validation to Renovate config changes
- add CI tools to the Nix dev shell and document the gates
- fix the active linkding deployment manifest schema issues found by kubeconform

## Validation
- nix develop --command actionlint
- nix flake check
- terraform fmt/validate in a clean temp checkout
- docker-compose config --quiet for active compose stacks
- kubectl kustomize | kubeconform for active Kubernetes overlays
- yq parse for Talos YAML
- git diff --check