### PR TITLE
ci: run quality gates on pull requests only

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -6,11 +6,6 @@ on:
       - main
     paths:
       - ".github/workflows/**"
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,13 +8,6 @@ on:
       - "docker/**"
       - ".github/workflows/_quality-gate.yaml"
       - ".github/workflows/docker.yaml"
-  push:
-    branches:
-      - main
-    paths:
-      - "docker/**"
-      - ".github/workflows/_quality-gate.yaml"
-      - ".github/workflows/docker.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -8,13 +8,6 @@ on:
       - "kubernetes/**"
       - ".github/workflows/_quality-gate.yaml"
       - ".github/workflows/kubernetes.yaml"
-  push:
-    branches:
-      - main
-    paths:
-      - "kubernetes/**"
-      - ".github/workflows/_quality-gate.yaml"
-      - ".github/workflows/kubernetes.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -9,14 +9,6 @@ on:
       - "flake.nix"
       - ".github/workflows/_quality-gate.yaml"
       - ".github/workflows/nix.yaml"
-  push:
-    branches:
-      - main
-    paths:
-      - "flake.lock"
-      - "flake.nix"
-      - ".github/workflows/_quality-gate.yaml"
-      - ".github/workflows/nix.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/talos.yaml
+++ b/.github/workflows/talos.yaml
@@ -8,13 +8,6 @@ on:
       - "talos/**"
       - ".github/workflows/_quality-gate.yaml"
       - ".github/workflows/talos.yaml"
-  push:
-    branches:
-      - main
-    paths:
-      - "talos/**"
-      - ".github/workflows/_quality-gate.yaml"
-      - ".github/workflows/talos.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -8,13 +8,6 @@ on:
       - "terraform/**"
       - ".github/workflows/_quality-gate.yaml"
       - ".github/workflows/terraform.yaml"
-  push:
-    branches:
-      - main
-    paths:
-      - "terraform/**"
-      - ".github/workflows/_quality-gate.yaml"
-      - ".github/workflows/terraform.yaml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- remove post-merge push triggers from path-scoped quality gate workflows
- keep pull_request and workflow_dispatch triggers for manual reruns
- leave scheduled/manual Renovate and manual runner test unchanged

## Validation
- nix shell .#actionlint --command actionlint
- git diff --check