### PR TITLE
docs(docker): document lsio capability baseline

### DIFF
--- a/docs/docker-hardening.md
+++ b/docs/docker-hardening.md
@@ -28,6 +28,23 @@ Applied capability drops:
 These changes intentionally exclude Docker socket controllers, database/cache
 services, LinuxServer.io images, GPU-backed media services, `immich-ml` after its healthcheck failed, and `pocket-id` after startup failed with `su-exec: setgroups(1000): Operation not permitted`.
 
+### Already-Applied Fresh-Volume Audit
+
+The LinuxServer.io fresh-volume issue does not directly apply to the currently
+applied capability drops because none of them are LSIO images. Do not back-apply
+the LSIO retained capability set to these containers without a specific failure:
+
+| Stack | Service | Fresh-volume capability risk |
+| --- | --- | --- |
+| `beszel` | `beszel` | Low. Image starts a single binary directly and has no observed ownership/bootstrap entrypoint. |
+| `couchdb` | `couchdb` | Watch. Compose pins `user: 5984:5984`, so the root `chown`/`chmod`/`setpriv` branch in the official entrypoint is bypassed. Keep the volume owned by uid/gid `5984`; if this service ever starts as root or uses host bind mounts, it needs retained init capabilities instead of bare `cap_drop: [ALL]`. |
+| `downloads` | `qbitwebui` | Low. Entrypoint only normalizes the command before launching Bun; no ownership repair or user switching observed. |
+| `miniflux` | `miniflux` | Low. Image runs as uid `65534` and has no writable volume in this repo; DB initialization is in the separate Postgres container, not the app container. |
+| `pinchflat` | `pinchflat` | Medium. Startup checks file permissions and exits on failure; it does not repair ownership. Root without capabilities can write to permissive/root-owned fresh named volumes, but host bind mounts such as `/downloads` must already be writable. |
+| `plex` | `seerr` | Low. Image runs as `node:node`; the `/app/config` volume is owned by uid/gid `1000` after initialization. |
+| `plex` | `kometa` | Low. Image starts via `tini` into Python and runs as root; no ownership repair or user switching observed. |
+| `audiobookshelf` | `audiobookshelf` | Low. Entrypoint only normalizes the command before launching Node; `NET_BIND_SERVICE` is retained only for port 80. |
+
 ## Research Baseline
 
 Docker Compose supports `cap_drop` and `cap_add`; Docker's default container
@@ -90,9 +107,11 @@ transcoding, not just container startup.
 Do not treat all LinuxServer.io images as unsupported for hardening. Their
 individual image pages are the source of truth for tested read-only and non-root
 operation. For this repo, keep capability drops separate from `user:` changes:
-`cap_drop: [ALL]` tests whether the normal rootful init path can start without
-Docker's default capabilities; `user:` changes bypass the normal `PUID`/`PGID`
-path and need the LSIO non-root recipe.
+the normal `PUID`/`PGID` path starts as root, runs s6 init, prepares users,
+folders, permissions, mods, custom files/services, and then starts the
+application as `abc`. A warm container with existing volumes can appear to work
+with `cap_drop: [ALL]`, but that is not a fresh-host bootstrap test. `user:`
+changes bypass the normal `PUID`/`PGID` path and need the LSIO non-root recipe.
 
 | Stack | Service | Image docs | Current notes |
 | --- | --- | --- | --- |
@@ -103,6 +122,21 @@ path and need the LSIO non-root recipe.
 | `downloads` | `qbittorrent` | https://docs.linuxserver.io/images/docker-qbittorrent/ | Page lists read-only and non-root operation; also validate TCP/UDP torrent listener. |
 | `downloads` | `sabnzbd` | https://docs.linuxserver.io/images/docker-sabnzbd/ | Page lists read-only and non-root operation; validate incomplete/complete download paths. |
 | `plex` | `tautulli` | https://docs.linuxserver.io/images/docker-tautulli/ | Page lists read-only and non-root operation; validate config DB writes and Plex connectivity. |
+
+For normal rootful LSIO operation on fresh volumes, do not start from
+`cap_drop: [ALL]` with no re-adds. Test a retained init capability set first:
+
+- `CHOWN`: required for startup ownership fixes on `/config` and bind mounts.
+- `SETUID` and `SETGID`: required for the init path to switch from root to the
+  configured `PUID`/`PGID`/`abc` user and group.
+- `DAC_OVERRIDE` and `FOWNER`: usually needed while root fixes permissions on
+  newly created or host-owned paths before the app drops privileges.
+- `KILL`: keep for s6 supervision and clean shutdown of services running as
+  the unprivileged app user.
+
+Only add service-specific capabilities after logs prove a need. For this repo's
+current LSIO services, no container listens below port 1024, so
+`NET_BIND_SERVICE` is not expected for the LSIO batch.
 
 LSIO non-root recipe notes:
 
@@ -149,7 +183,7 @@ into read-only API access.
 2. Deploy the low-risk app batch one stack at a time: `couchdb`, `pinchflat`, `qbitwebui`, `seerr`, `kometa`, and `miniflux`.
 3. Deploy low-port standalone apps such as `audiobookshelf` with only `NET_BIND_SERVICE` re-added when needed.
 4. Try GPU services only when prepared to validate actual transcoding.
-5. Treat LinuxServer.io services as their own batch and follow each image's docs; if `cap_drop: [ALL]` fails on the normal `PUID`/`PGID` path, test a minimal re-add set starting with `CHOWN`, `SETUID`, and `SETGID`.
+5. Treat LinuxServer.io services as their own batch and preserve the fresh-host init capabilities above before removing more.
 6. Convert DB/cache services to fixed users with pre-owned volumes before dropping all capabilities, or retain the init capabilities their official entrypoints need.
 7. Address Traefik's Docker socket before spending much time on smaller capability tweaks there.
 
@@ -169,7 +203,7 @@ Known exception patterns:
 - Database images can require `CHOWN`, `SETUID`, or `SETGID` during init unless volumes are pre-owned and the service runs as a fixed non-root user.
 - GPU-backed services need explicit `/dev/dri` validation after capability drops.
 - Services with Docker socket access should be moved to a socket proxy before deeper hardening.
-- LinuxServer.io images should be tested separately because their init path configures users, folders, permissions, and services before the app starts.
+- LinuxServer.io images should be tested with fresh empty volumes because their init path configures users, folders, permissions, and services before the app starts.
 
 ## Later Passes
 


### PR DESCRIPTION
## Summary
- document why LinuxServer.io containers need fresh-host bootstrap validation
- record the retained init capability baseline for normal PUID/PGID operation
- update rollout guidance to preserve LSIO init capabilities before removing more

## Validation
- git diff --check --cached