### PR TITLE
Set NFS media binds to rslave

### DIFF
--- a/docker/arrs/compose.yml
+++ b/docker/arrs/compose.yml
@@ -13,7 +13,11 @@ services:
       - TZ=${TZ}
     volumes:
       - radarr-data:/config
-      - /mnt/data:/data:rw
+      - type: bind
+        source: /mnt/data
+        target: /data
+        bind:
+          propagation: rslave
     labels:
       - traefik.enable=true
       - traefik.http.routers.radarr.rule=Host(`radarr.local.elmurphy.com`)
@@ -34,7 +38,11 @@ services:
       - TZ=${TZ}
     volumes:
       - sonarr-data:/config
-      - /mnt/data:/data:rw
+      - type: bind
+        source: /mnt/data
+        target: /data
+        bind:
+          propagation: rslave
     labels:
       - traefik.enable=true
       - traefik.http.routers.sonarr.rule=Host(`sonarr.local.elmurphy.com`)
@@ -55,8 +63,16 @@ services:
       - TZ=${TZ}
     volumes:
       - lidarr-data:/config
-      - /mnt/data:/data:rw
-      - /mnt/music:/music:rw
+      - type: bind
+        source: /mnt/data
+        target: /data
+        bind:
+          propagation: rslave
+      - type: bind
+        source: /mnt/music
+        target: /music
+        bind:
+          propagation: rslave
     labels:
       - traefik.enable=true
       - traefik.http.routers.lidarr.rule=Host(`lidarr.local.elmurphy.com`)

--- a/docker/audiobookshelf/compose.yml
+++ b/docker/audiobookshelf/compose.yml
@@ -14,7 +14,11 @@ services:
     environment:
       - TZ=${TZ}
     volumes:
-      - /mnt/audiobooks:/data/audiobooks:rw
+      - type: bind
+        source: /mnt/audiobooks
+        target: /data/audiobooks
+        bind:
+          propagation: rslave
       - audiobookshelf-data:/config
       - audiobookshelf-data:/metadata
     labels:

--- a/docker/downloads/compose.yml
+++ b/docker/downloads/compose.yml
@@ -20,7 +20,11 @@ services:
       - TORRENTING_PORT=25565
     volumes:
       - qbittorrent-data:/config
-      - /mnt/data/torrents:/data/torrents:rw
+      - type: bind
+        source: /mnt/data/torrents
+        target: /data/torrents
+        bind:
+          propagation: rslave
     ports:
       - 25565:25565
       - 25565:25565/udp
@@ -46,7 +50,11 @@ services:
       - DISABLE_REGISTRATION=true # NOTE: prints initial password to logs on first start
     volumes:
       - qbitwebui-data:/data
-      - /mnt/data/torrents:/data/torrents:rw
+      - type: bind
+        source: /mnt/data/torrents
+        target: /data/torrents
+        bind:
+          propagation: rslave
     labels:
       - traefik.enable=true
       - traefik.http.routers.qbitwebui.rule=Host(`qbitwebui.local.elmurphy.com`)
@@ -70,7 +78,11 @@ services:
       - TZ=${TZ}
     volumes:
       - sabnzbd-data:/config
-      - /mnt/data/usenet:/data/usenet:rw
+      - type: bind
+        source: /mnt/data/usenet
+        target: /data/usenet
+        bind:
+          propagation: rslave
     labels:
       - traefik.enable=true
       - traefik.http.routers.sabnzbd.rule=Host(`sabnzbd.local.elmurphy.com`)

--- a/docker/jellyfin/compose.yml
+++ b/docker/jellyfin/compose.yml
@@ -17,8 +17,18 @@ services:
     volumes:
       - jellyfin-data:/config
       - jellyfin-cache:/cache
-      - /mnt/data/media:/data/media:ro
-      - /mnt/music:/data/music:ro
+      - type: bind
+        source: /mnt/data/media
+        target: /data/media
+        read_only: true
+        bind:
+          propagation: rslave
+      - type: bind
+        source: /mnt/music
+        target: /data/music
+        read_only: true
+        bind:
+          propagation: rslave
       - /dev/shm:/transcode # ram transcode
     ports:
       - 8096:8096 

--- a/docker/pinchflat/compose.yml
+++ b/docker/pinchflat/compose.yml
@@ -12,7 +12,11 @@ services:
     environment:
       - TZ=${TZ}
     volumes:
-      - /mnt/data/media/youtube:/downloads:rw
+      - type: bind
+        source: /mnt/data/media/youtube
+        target: /downloads
+        bind:
+          propagation: rslave
       - pinchflat-data:/config
     labels:
       - traefik.enable=true

--- a/docker/plex/compose.yml
+++ b/docker/plex/compose.yml
@@ -18,8 +18,16 @@ services:
     volumes:
       - plex-data:/config
       - plex-transcode:/transcode
-      - /mnt/data/media:/data/media:rw
-      - /mnt/music:/data/music:rw
+      - type: bind
+        source: /mnt/data/media
+        target: /data/media
+        bind:
+          propagation: rslave
+      - type: bind
+        source: /mnt/music
+        target: /data/music
+        bind:
+          propagation: rslave
     labels:
       - traefik.enable=true
       - traefik.http.routers.plex.rule=Host(`plex.local.elmurphy.com`)


### PR DESCRIPTION
## Summary
- convert TrueNAS-backed media bind mounts to long syntax with `bind.propagation: rslave`
- preserve writable mounts for Arr/download/Plex/Audiobookshelf/Pinchflat services
- preserve Jellyfin media mounts as read-only

## Validation
- `git diff --check`
- changed compose files render with `docker compose -f <file> config`
- full `docker/**/compose.yml` render check passes with CI-style placeholder environment values