### PR TITLE
Add Docker healthchecks for app containers

### DIFF
--- a/docker/arrs/compose.yml
+++ b/docker/arrs/compose.yml
@@ -32,6 +32,12 @@ services:
       - traefik.http.routers.radarr.rule=Host(`radarr.local.elmurphy.com`)
       - traefik.http.routers.radarr.tls=true
       - traefik.http.services.radarr.loadbalancer.server.port=7878
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7878/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   sonarr:
@@ -66,6 +72,12 @@ services:
       - traefik.http.routers.sonarr.rule=Host(`sonarr.local.elmurphy.com`)
       - traefik.http.routers.sonarr.tls=true
       - traefik.http.services.sonarr.loadbalancer.server.port=8989
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8989/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   lidarr:
@@ -105,6 +117,12 @@ services:
       - traefik.http.routers.lidarr.rule=Host(`lidarr.local.elmurphy.com`)
       - traefik.http.routers.lidarr.tls=true
       - traefik.http.services.lidarr.loadbalancer.server.port=8686
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8686/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   prowlarr:
@@ -134,6 +152,12 @@ services:
       - traefik.http.routers.prowlarr.rule=Host(`prowlarr.local.elmurphy.com`)
       - traefik.http.routers.prowlarr.tls=true
       - traefik.http.services.prowlarr.loadbalancer.server.port=9696
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9696/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker/audiobookshelf/compose.yml
+++ b/docker/audiobookshelf/compose.yml
@@ -26,6 +26,12 @@ services:
       - traefik.http.routers.audiobookshelf.rule=Host(`audiobookshelf.local.elmurphy.com`)
       - traefik.http.routers.audiobookshelf.tls=true
       - traefik.http.services.audiobookshelf.loadbalancer.server.port=80
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 volumes:
   audiobookshelf-data:

--- a/docker/couchdb/compose.yml
+++ b/docker/couchdb/compose.yml
@@ -27,6 +27,12 @@ services:
       - traefik.http.middlewares.obsidiancors.headers.accesscontrolmaxage=3600
       - traefik.http.middlewares.obsidiancors.headers.addvaryheader=true
       - traefik.http.middlewares.obsidiancors.headers.accessControlAllowCredentials=true
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:5984/_up"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker/downloads/compose.yml
+++ b/docker/downloads/compose.yml
@@ -42,6 +42,12 @@ services:
       - traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.local.elmurphy.com`)
       - traefik.http.routers.qbittorrent.tls=true
       - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   qbitwebui:
@@ -69,6 +75,12 @@ services:
       - traefik.http.routers.qbitwebui.rule=Host(`qbitwebui.local.elmurphy.com`)
       - traefik.http.routers.qbitwebui.tls=true
       - traefik.http.services.qbitwebui.loadbalancer.server.port=3000
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   # NOTE: initial setup is done via "http://<docker localhost ip>:8080"
@@ -106,6 +118,12 @@ services:
       - traefik.http.routers.sabnzbd.rule=Host(`sabnzbd.local.elmurphy.com`)
       - traefik.http.routers.sabnzbd.tls=true
       - traefik.http.services.sabnzbd.loadbalancer.server.port=8080
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker/init/compose.yml
+++ b/docker/init/compose.yml
@@ -54,6 +54,12 @@ services:
       - "traefik.http.routers.traefik-secure.tls.domains[0].main=local.elmurphy.com"
       - "traefik.http.routers.traefik-secure.tls.domains[0].sans=*.local.elmurphy.com"
       - "traefik.http.routers.traefik-secure.service=api@internal"
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   pocket-id:

--- a/docker/init/traefik.yml
+++ b/docker/init/traefik.yml
@@ -5,6 +5,7 @@ global:
 api:
   dashboard: true
   debug: true
+ping: {}
 entryPoints:
   web:
     address: ":80"

--- a/docker/miniflux/compose.yml
+++ b/docker/miniflux/compose.yml
@@ -21,6 +21,12 @@ services:
       - traefik.http.routers.miniflux.rule=Host(`miniflux.local.elmurphy.com`)
       - traefik.http.routers.miniflux.tls=true
       - traefik.http.services.miniflux.loadbalancer.server.port=8080
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       miniflux-db:
         condition: service_healthy

--- a/docker/plex/compose.yml
+++ b/docker/plex/compose.yml
@@ -62,6 +62,12 @@ services:
       - traefik.http.routers.tautulli.rule=Host(`tautulli.local.elmurphy.com`)
       - traefik.http.routers.tautulli.tls=true
       - traefik.http.services.tautulli.loadbalancer.server.port=8181
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8181/status"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   seerr:
@@ -84,6 +90,12 @@ services:
       - traefik.http.routers.seerr.rule=Host(`seerr.local.elmurphy.com`)
       - traefik.http.routers.seerr.tls=true
       - traefik.http.services.seerr.loadbalancer.server.port=5055
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:5055/api/v1/status"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   # Manually setup initial config


### PR DESCRIPTION
## Summary
- add Docker healthchecks for app containers with validated local HTTP/readiness probes
- enable Traefik ping and add its built-in healthcheck command
- leave containers unchanged where healthchecks already exist from compose/image metadata or where no reliable in-container probe is available

## Added healthchecks
- audiobookshelf
- couchdb
- radarr, sonarr, lidarr, prowlarr
- qbittorrent, qbitwebui, sabnzbd
- miniflux
- tautulli, seerr
- traefik

## Reviewed but unchanged
- Existing compose/image healthchecks: immich, immich-ml, immich-postgres, immich-redis, jellyfin, miniflux-db, owncloud, owncloud-mariadb, owncloud-redis, pinchflat, plex, pocket-id, wallabag, wallabag-mariadb, wallabag-redis
- Skipped: kometa has no resident HTTP service; beszel and portainer images have no shell/curl/wget probe tools available for a compose-level healthcheck

## Validation
- Validated each new probe command inside the corresponding live container on docker-host
- docker compose config rendered successfully for arrs, downloads, plex, audiobookshelf, couchdb, miniflux, and init stacks
- git diff --check

Note: compose render emitted expected local warnings for unset env vars.