### PR TITLE
fix(terraform): install tailscale from pinned distro repos and keep auth key out of logs

### DIFF
--- a/terraform/cloud_init.tftpl
+++ b/terraform/cloud_init.tftpl
@@ -4,14 +4,26 @@ hostname: ${hostname}
 fqdn: ${hostname}
 manage_etc_hosts: true
 
+# root-only file keeps the auth key out of process args and cloud-init logs
+write_files:
+  - path: /etc/tailscale/authkey
+    owner: "root:root"
+    permissions: "0600"
+    content: "${tailscale_auth_key}"
+
 %{ if os_family == "debian" ~}
 package_update: true
 packages:
   - qemu-guest-agent
 runcmd:
   - systemctl enable --now qemu-guest-agent
-  - curl -fsSL https://tailscale.com/install.sh | sh
-  - tailscale up --ssh --hostname=${hostname} --authkey=${tailscale_auth_key}
+  # pinned vendor repo instead of curl | sh
+  - . /etc/os-release && curl -fsSL "https://pkgs.tailscale.com/stable/$ID/$VERSION_CODENAME.noarmor.gpg" -o /usr/share/keyrings/tailscale-archive-keyring.gpg
+  - . /etc/os-release && curl -fsSL "https://pkgs.tailscale.com/stable/$ID/$VERSION_CODENAME.tailscale-keyring.list" -o /etc/apt/sources.list.d/tailscale.list
+  - apt-get update
+  - apt-get install -y tailscale
+  - systemctl enable --now tailscaled
+  - tailscale up --ssh --hostname=${hostname} --auth-key=file:/etc/tailscale/authkey && rm -f /etc/tailscale/authkey
 %{ endif ~}
 %{ if os_family == "arch" ~}
 packages:
@@ -22,6 +34,7 @@ runcmd:
   - pacman-key --populate archlinux
   - pacman -Sy --noconfirm archlinux-keyring
   - pacman -Syu --noconfirm
-  - curl -fsSL https://tailscale.com/install.sh | sh
-  - tailscale up --ssh --hostname=${hostname} --advertise-tags=tag:ai-dev --authkey=${tailscale_auth_key}
+  - pacman -S --noconfirm tailscale
+  - systemctl enable --now tailscaled
+  - tailscale up --ssh --hostname=${hostname} --advertise-tags=tag:ai-dev --auth-key=file:/etc/tailscale/authkey && rm -f /etc/tailscale/authkey
 %{ endif ~}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,9 +8,11 @@ locals {
   srv_vlan_id  = 20
   scp          = data.onepassword_item.proxmox.section_map["Terraform SCP"].field_map
   proxmox_creds = {
-    username           = local.scp["scp username"].value
-    password           = local.scp["scp password"].value
-    host               = local.scp["hostname"].value
+    username = local.scp["scp username"].value
+    password = local.scp["scp password"].value
+    host     = local.scp["hostname"].value
+    # use an ephemeral/tagged single-use key; the previous shared key leaked into
+    # cloud-init logs and must be rotated in the Tailscale admin console
     tailscale_auth_key = local.scp["tailscale authkey"].value
   }
 }


### PR DESCRIPTION
## Finding (security review — High)

`cloud_init.tftpl` installed Tailscale via `curl ... install.sh | sh` (unpinned remote script run as root) and joined the tailnet with `tailscale up --authkey <key>` in `runcmd` — putting the long-lived shared auth key into process args and `/var/log/cloud-init-output.log` on every VM.

## Changes

- Tailscale installed from distro packages: Ubuntu/Debian via the official apt repo with the GPG keyring pinned (`signed-by`), Arch via `pacman -S tailscale`. No remote scripts piped to a shell.
- Auth key delivered via cloud-init `write_files` (root:root, 0600, `/etc/tailscale/authkey`), consumed with `tailscale up --auth-key=file:...`, and removed after a successful join — the key never appears in process args or cloud-init output.
- `systemctl enable --now tailscaled` added explicitly (previously done by install.sh).
- Comment in `main.tf` recommending ephemeral/tagged single-use keys.

## Quality gate (independently verified)

- No `curl|sh` remains under `terraform/`
- Both OS branches rendered with a dummy key and parsed: key lands only in `write_files`, never in `runcmd`
- All prior cloud-init behavior preserved (hostname, qemu-guest-agent, `--ssh`, `--advertise-tags`)
- `terraform fmt -check -recursive` and `terraform validate` pass

## Manual follow-up (not in this PR)

- **Rotate the existing shared auth key in the Tailscale admin console** — it has already been exposed via cloud-init logs on provisioned VMs. Prefer an ephemeral or tagged single-use key going forward.
- Note: if a join fails, the 0600 key file persists on the VM until cleaned up manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)