### PR TITLE
fix(firewall): gate docker-published ports via DOCKER-USER allowlist

### DIFF
--- a/ansible/group_vars/docker.yaml
+++ b/ansible/group_vars/docker.yaml
@@ -9,3 +9,13 @@ swap_swappiness: 10
 
 # enables the firewall rule letting the compose bridge reach Tailscale
 firewall_docker_bridge_subnet: 172.20.1.0/24
+
+# enables DOCKER-USER filtering (see roles/firewall); docker-published ports
+# not listed here are dropped
+firewall_docker_allowed_ports:
+  - {port: 80, proto: tcp}  # traefik
+  - {port: 443, proto: tcp}  # traefik
+  - {port: 9443, proto: tcp}  # portainer escape hatch
+  - {port: 8096, proto: tcp}  # jellyfin
+  - {port: 25565, proto: tcp}  # qbittorrent peers
+  - {port: 25565, proto: udp}  # qbittorrent peers

--- a/ansible/roles/firewall/defaults/main.yaml
+++ b/ansible/roles/firewall/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+# DOCKER-USER filtering applies only to traffic entering here; tailscale0 and
+# docker bridges are unaffected
+firewall_docker_external_interface: "{{ ansible_default_ipv4.interface }}"

--- a/ansible/roles/firewall/tasks/main.yaml
+++ b/ansible/roles/firewall/tasks/main.yaml
@@ -34,6 +34,28 @@
   loop: "{{ firewall_allow_ports | default([]) }}"
   notify: reload ufw
 
+# docker-host only: docker's DNAT/FORWARD rules bypass ufw's default-deny, so
+# published ports must be allowlisted in DOCKER-USER instead (ufw-docker
+# pattern, github.com/chaifeng/ufw-docker). after.rules survives reboots and
+# docker restarts; only NEW connections on the external interface are filtered.
+- name: allowlist docker published ports in DOCKER-USER
+  ansible.builtin.blockinfile:
+    path: /etc/ufw/after.rules
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: docker published-port allowlist"
+    block: |
+      *filter
+      :DOCKER-USER - [0:0]
+      -A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+      -A DOCKER-USER -m conntrack --ctstate INVALID -j DROP
+      {% for entry in firewall_docker_allowed_ports %}
+      -A DOCKER-USER -i {{ firewall_docker_external_interface }} -p {{ entry.proto }} -m conntrack --ctdir ORIGINAL --ctorigdstport {{ entry.port }} -j RETURN
+      {% endfor %}
+      -A DOCKER-USER -i {{ firewall_docker_external_interface }} -m conntrack --ctstate NEW -j DROP
+      -A DOCKER-USER -j RETURN
+      COMMIT
+  when: firewall_docker_allowed_ports is defined
+  notify: reload ufw
+
 # docker-host only: lets the compose bridge reach the Tailscale CGNAT range.
 # Enabled by setting firewall_docker_bridge_subnet in group vars.
 - name: allow internal docker bridge to tailscale

--- a/docker/init/compose.yml
+++ b/docker/init/compose.yml
@@ -11,7 +11,7 @@ services:
       - portainer-data:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:
-      - 8000:8000
+      # escape hatch when traefik is down; allowlisted in firewall_docker_allowed_ports
       - 9443:9443
     labels:
       - traefik.enable=true


### PR DESCRIPTION
## Finding (security review — High)

UFW's default-deny on docker-host never applied to Docker-published ports: Docker inserts its DNAT/FORWARD rules ahead of UFW, so every `ports:` publish was LAN-reachable regardless of UFW policy. Portainer's Edge-agent port 8000 (unused) was exposed to the whole SRV subnet.

## Changes

- Removed the unused `8000:8000` publish from Portainer (`9443` kept as a deliberate Traefik-down escape hatch).
- Firewall role now manages the `DOCKER-USER` chain via a blockinfile-managed section in `/etc/ufw/after.rules` (ufw-docker pattern): NEW inbound on the external interface to a published port is dropped unless the port is in `firewall_docker_allowed_ports` (defined in `group_vars/docker.yaml`; the unifi host skips the task entirely).
- Allow rules match the pre-DNAT published port via `conntrack --ctorigdstport`; established/related and container-originated traffic unaffected; Tailscale-sourced traffic falls through to RETURN.

## Resulting policy (all published ports enumerated repo-wide)

| Port | Service | Decision |
|---|---|---|
| 80, 443/tcp | traefik | allow |
| 9443/tcp | portainer | allow (escape hatch) |
| 8096/tcp | jellyfin | allow (current behavior preserved) |
| 25565/tcp+udp | qbittorrent | allow (torrent ingress) |
| 8000/tcp | portainer edge | **publish removed** |

All other stacks are Traefik-only; no `network_mode: host` services exist.

## Quality gate (independently verified)

- Rendered after.rules block is valid iptables-restore input; does not touch INPUT, SSH, FORWARD jump, or existing Tailscale rules — no lockout path (SSH terminates in INPUT, untouched)
- Idempotent (blockinfile + ufw reload handler; second run reports no change)
- yamllint clean; ansible-lint shows only the repo's pre-existing lowercase-name convention findings

## Post-merge verification on docker-host

1. `sudo iptables -L DOCKER-USER -nv` — allowlist present, correct external interface (override `firewall_docker_external_interface` if the default fact picks wrong)
2. From a LAN client: `nmap -sT -p 80,443,8000,8096,9443,25565 docker-host` → 8000 filtered, rest open; canary: `docker run --rm -p 18080:80 nginx` should be unreachable
3. `sudo systemctl restart docker` and one reboot → rules intact
4. Confirm container outbound and Tailscale access still work

Note: IPv6 not covered (docker ip6tables is off; v6 listeners hit UFW INPUT default-deny).

🤖 Generated with [Claude Code](https://claude.com/claude-code)