### PR TITLE
fix(docker): move Traefik off the raw Docker socket via socket proxy

### DIFF
--- a/docker/init/compose.yml
+++ b/docker/init/compose.yml
@@ -22,6 +22,36 @@ services:
       - traefik
     restart: unless-stopped
 
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
+    container_name: docker-socket-proxy
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    # entrypoint renders haproxy.cfg into /tmp; haproxy writes its pidfile to /run
+    tmpfs:
+      - /tmp
+      - /run
+    networks:
+      - docker-socket-proxy
+    environment:
+      - CONTAINERS=1
+      - EVENTS=1
+      - PING=1
+      - POST=0
+      - VERSION=1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:2375/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+
   traefik:
     image: traefik:v3.7.4@sha256:fcdef599e6259359833dd2e1d49f9e964f66825d69bd3dd468f51102ce013d03
     container_name: traefik
@@ -29,12 +59,12 @@ services:
       - no-new-privileges:true
     networks:
       - proxy
+      - docker-socket-proxy
     environment:
       - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}
       - CF_API_EMAIL=${CF_API_EMAIL}
     volumes:
       - traefik-data:/letsencrypt
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik.yml:/traefik.yml:ro
       - ./traefik-dynamic.yml:/traefik-dynamic.yml:ro
     ports:
@@ -60,6 +90,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
+    depends_on:
+      - docker-socket-proxy
     restart: unless-stopped
 
   pocket-id:
@@ -108,3 +140,6 @@ networks:
     ipam:
       config:
         - subnet: 172.20.1.0/24
+  docker-socket-proxy:
+    name: docker-socket-proxy
+    internal: true

--- a/docker/init/traefik.yml
+++ b/docker/init/traefik.yml
@@ -21,7 +21,7 @@ serversTransport:
   insecureSkipVerify: true
 providers:
   docker:
-    endpoint: "unix:///var/run/docker.sock"
+    endpoint: "tcp://docker-socket-proxy:2375"
     exposedByDefault: false
     network: proxy
   file:

--- a/docs/docker-hardening.md
+++ b/docs/docker-hardening.md
@@ -243,3 +243,15 @@ Known exception patterns:
 
 After capability drops are stable, evaluate `read_only: true` service by service
 with explicit `tmpfs` entries for required writable runtime paths.
+
+## Docker Socket Proxy Rollout
+
+Traefik uses the Tecnativa Docker Socket Proxy on an internal-only network
+instead of mounting `/var/run/docker.sock` directly. Portainer keeps its direct
+socket mount as the explicit Docker API controller.
+
+The proxy is GET-only (`POST=0`): `CONTAINERS` is granted for label discovery
+plus the image-default `EVENTS`/`PING`/`VERSION`, matching what Traefik's
+non-swarm provider actually calls. `INFO` and `NETWORKS` stay denied. It runs
+with `cap_drop: ALL` and `read_only` (tmpfs on `/tmp` and `/run`), validated
+against the pinned image with a live socket.


### PR DESCRIPTION
## Finding (security review — High)

Traefik mounted `/var/run/docker.sock` directly — `:ro` does not restrict the Docker API, so compromise of the TLS edge meant root on the host. Traefik's own docs flag this and name the Tecnativa socket proxy as the filtering solution.

## Changes

- New `docker-socket-proxy` service (`ghcr.io/tecnativa/docker-socket-proxy:v0.4.2`, digest-pinned and verified against ghcr) on a dedicated `internal: true` network shared only with Traefik.
- GET-only API surface matched to what Traefik's non-swarm provider actually calls (`ServerVersion`, `ContainerList`/inspect, `Events`, `/_ping`): `CONTAINERS=1` plus the `EVENTS`/`PING`/`VERSION` image defaults, `POST=0`. `INFO`/`NETWORKS` stay denied.
- Hardened per repo pattern: socket `:ro`, `no-new-privileges`, `cap_drop: ALL`, `read_only` with tmpfs on `/tmp` and `/run` (entrypoint renders haproxy.cfg into `/tmp`, pidfile in `/run`), wget `/version` healthcheck.
- Traefik: socket mount removed, provider endpoint → `tcp://docker-socket-proxy:2375`, `depends_on` (provider also retries with exponential backoff). Portainer's documented-intentional socket mount untouched.

## Quality gate (independently verified, including empirically)

- Pinned image run locally with the exact hardening flags against a live socket: starts clean, healthcheck exits 0, allowed GETs return 200, `/info`, `/images/json`, and all POSTs return 403
- Grant set cross-checked against Traefik v3 docs, Traefik 3.7 provider source, and Tecnativa's documented defaults
- CI-equivalent `docker compose config` passes

## Post-deploy checklist on docker-host

1. `docker compose up -d` in `docker/init` — `docker-socket-proxy` healthy within ~30s
2. `docker logs traefik` — no provider connection errors
3. Dashboard router count unchanged (label discovery still works)
4. `docker logs docker-socket-proxy` — GET traffic only; any 403 means a missing section (none expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)