### PR TITLE
fix(firewall): flush DOCKER-USER before ufw reload so allowlist edits apply

### DIFF
--- a/ansible/roles/firewall/handlers/main.yaml
+++ b/ansible/roles/firewall/handlers/main.yaml
@@ -1,4 +1,14 @@
 ---
+# ufw reload re-renders after.rules into the still-loaded DOCKER-USER chain,
+# appending below its terminal RETURN; flush first so edits take effect
+- name: flush docker-user chain
+  ansible.builtin.command: iptables -F DOCKER-USER
+  register: docker_user_flush
+  changed_when: docker_user_flush.rc == 0
+  failed_when:
+    - docker_user_flush.rc != 0
+    - "'No chain' not in docker_user_flush.stderr"
+
 - name: reload ufw
   community.general.ufw:
     state: reloaded

--- a/ansible/roles/firewall/tasks/main.yaml
+++ b/ansible/roles/firewall/tasks/main.yaml
@@ -54,7 +54,9 @@
       -A DOCKER-USER -j RETURN
       COMMIT
   when: firewall_docker_allowed_ports is defined
-  notify: reload ufw
+  notify:
+    - flush docker-user chain
+    - reload ufw
 
 # docker-host only: lets the compose bridge reach the Tailscale CGNAT range.
 # Enabled by setting firewall_docker_bridge_subnet in group vars.


### PR DESCRIPTION
## Problem

Follow-up to #1520. `ufw reload` loads `after.rules` with `iptables-restore -n` (no flush), and neither `ufw-init stop` nor reload touches non-ufw chains. So when `firewall_docker_allowed_ports` changes, the re-rendered block is **appended below the still-loaded chain's terminal `RETURN`** — the new rules are never evaluated and the old policy stays active until a reboot. Ansible reports changed, the file on disk looks correct: the failure is silent.

## Change

New `flush docker-user chain` handler (`iptables -F DOCKER-USER`) ordered before `reload ufw` in the handlers file; the blockinfile task now notifies both. The reload then rebuilds the chain from the rendered file in correct order.

- `failed_when` tolerates a missing chain (fresh host where neither ufw nor docker has created it yet)
- Docker's startup is unaffected: it only ensures the chain exists and won't re-add its own `RETURN` since the rendered block ends with one
- The sub-second unfiltered window between flush and reload is the same exposure as pre-#1520; other handlers' notify paths (`reload ufw` alone) are unchanged

## Verification

Syntax-checked locally; quality-gate lint runs in CI. Live mechanism test deferred to the next role run on docker-host — verify with:

```
sudo iptables -L DOCKER-USER -nv   # rules present, allowlist order, single copy
```

after any edit to `firewall_docker_allowed_ports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)