### PR TITLE
fix(docker): stop deleting /srv/init and force-recreating the init stack

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -87,31 +87,18 @@
     dest: "{{ clone_dir }}"
     depth: 1
 
-- name: confirm clone directory exists
-  ansible.builtin.stat:
-    path: "{{ clone_dir }}"
-  register: repo
-
-- name: delete existing docker directory
-  ansible.builtin.file:
-    path: "{{ srv_dir }}"
-    state: absent
-  when: repo.stat.exists
-
-- name: copy init compose file
+- name: sync init compose files
   ansible.builtin.copy:
     remote_src: true
     src: "{{ clone_dir }}/docker/init/"
     dest: "{{ srv_dir }}/"
     owner: "{{ username }}"
     mode: "0775"
-  when: repo.stat.exists
 
 - name: delete clone directory
   ansible.builtin.file:
     path: "{{ clone_dir }}"
     state: absent
-  when: repo.stat.exists
 
 - name: ensure Pocket ID secret directory exists
   ansible.builtin.file:
@@ -168,7 +155,9 @@
     mode: "0600"
   no_log: true
 
+# no --force-recreate: compose only recreates services whose config/image changed
 - name: start init compose file
-  ansible.builtin.shell:
-    cmd: docker compose up -d --force-recreate
+  ansible.builtin.command:
+    cmd: docker compose up -d --remove-orphans
     chdir: "{{ srv_dir }}"
+  changed_when: true  # compose reconciles state itself; reporting changed is the safe default


### PR DESCRIPTION
## Finding (security review — Medium)

The docker role deleted `/srv/init` and ran `docker compose up -d --force-recreate` on every run — briefly destroying the live reverse-proxy/auth stack (traefik, portainer, pocket-id, docker-socket-proxy), wiping operator backups in `/srv/init`, and making every full ansible run a production event. This forced risky targeted-deploy workarounds during the #1520 and #1521 rollouts.

## Changes

- `/srv/init` is no longer deleted; repo files are synced in place (changed files updated, nothing else touched).
- `--force-recreate` dropped in favor of `docker compose up -d --remove-orphans`: compose recreates only services whose config or image changed, and cleans up services removed from the compose file.
- Dead `stat`/`when: repo.stat.exists` guards removed (the git clone task already fails the play on error); final task switched from `shell` to `command`.

## Behavior notes

- First run after this merges is a quiet no-op unless compose config actually differs.
- Files removed from `docker/init/` in the repo will linger in `/srv/init` (accepted trade-off; stale *services* are handled by `--remove-orphans`).
- The `.env` and Pocket ID key tasks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
