### PR TITLE
fix(traefik): scope insecureSkipVerify to self-signed backends

### DIFF
--- a/docker/init/traefik-dynamic.yml
+++ b/docker/init/traefik-dynamic.yml
@@ -23,6 +23,10 @@ tls:
         - CurveP256
         - CurveP384
 http:
+  serversTransports:
+    # only for proxmox/truenas backends with self-signed certs; never global
+    insecure-internal:
+      insecureSkipVerify: true
   routers:
     proxmox:
       entryPoints:
@@ -48,11 +52,13 @@ http:
         servers:
           - url: "https://10.77.1.100:8006"
         passHostHeader: true
+        serversTransport: insecure-internal
     truenas:
       loadBalancer:
         servers:
           - url: "https://10.77.20.101"
         passHostHeader: true
+        serversTransport: insecure-internal
   middlewares:
     https-redirectscheme:
       redirectScheme:
@@ -73,7 +79,7 @@ http:
     default-whitelist:
       ipAllowList:
         sourceRange:
-        - "100.0.0.0/8"
+        - "100.64.0.0/10"
         - "10.77.1.0/24"
         - "172.20.1.0/24"
     secured:

--- a/docker/init/traefik.yml
+++ b/docker/init/traefik.yml
@@ -4,7 +4,6 @@ global:
   sendAnonymousUsage: false
 api:
   dashboard: true
-  debug: true
 ping: {}
 entryPoints:
   web:
@@ -17,8 +16,6 @@ entryPoints:
   websecure:
     address: ":443"
     asDefault: true
-serversTransport:
-  insecureSkipVerify: true
 providers:
   docker:
     endpoint: "tcp://docker-socket-proxy:2375"


### PR DESCRIPTION
## Finding (security review — Medium)

`docker/init/traefik.yml` set `serversTransport.insecureSkipVerify: true` globally, disabling backend TLS verification for every proxied service, and left `api.debug: true` enabled. `docker/init/traefik-dynamic.yml` allowlisted `100.0.0.0/8`, which includes publicly routable space beyond Tailscale's CGNAT range.

## Changes

- Global `insecureSkipVerify` removed. A named serversTransport `insecure-internal` now carries it, referenced only by the `proxmox` and `truenas` services — the two backends serving self-signed certs (`https://10.77.1.100:8006`, `https://10.77.20.101`). All other backends get verified TLS.
- `api.debug` removed (dashboard stays enabled; access remains gated by Tailscale/LAN reachability).
- `default-whitelist` source range tightened from `100.0.0.0/8` to `100.64.0.0/10`.

## Deploy notes

- The init stack is ansible-managed (`/srv/init`), not Portainer GitOps. Apply with the docker role (after #1524 merges, the role no longer force-recreates) or a targeted `sudo docker compose up -d traefik` in `/srv/init` after syncing the two config files.
- No published ports change; ufw/DOCKER-USER rules are unaffected.

Dashboard auth (Pocket ID forward-auth) was considered and deliberately dropped — all access already rides the Tailscale VPN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
