### PR TITLE
fix(ansible): strict host keys, sshd validation, pinned unifi checksum

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,8 +1,11 @@
 [defaults]
-host_key_checking = False
 inventory = ./hosts.ini
 interpreter_python = auto_silent
 remote_user = ansible
 
 [privilege_escalation]
 become_ask_pass = False
+
+[ssh_connection]
+# accept-new: trust host keys on first connect, strict thereafter; keeps ansible's default args
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=accept-new

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,5 +1,6 @@
 ---
 collections:
+  - ansible.posix
   - community.general
   - kewlfft.aur
   # MikroTik RouterOS API (routeros role)

--- a/ansible/roles/common/tasks/ssh.yaml
+++ b/ansible/roles/common/tasks/ssh.yaml
@@ -5,6 +5,7 @@
     regexp: "^\\s*#?\\s*PermitRootLogin\\s+.*$"
     line: "PermitRootLogin no"
     state: present
+    validate: /usr/sbin/sshd -t -f %s
   notify: "restart sshd service"
 
 - name: disable password authentication
@@ -13,6 +14,7 @@
     regexp: "^\\s*#?\\s*PasswordAuthentication\\s+.*$"
     line: "PasswordAuthentication no"
     state: present
+    validate: /usr/sbin/sshd -t -f %s
   notify: "restart sshd service"
 
 - name: disable any keyboard interactive authentication
@@ -21,6 +23,7 @@
     regexp: "^\\s*#?\\s*KbdInteractiveAuthentication\\s+.*$"
     line: "KbdInteractiveAuthentication no"
     state: present
+    validate: /usr/sbin/sshd -t -f %s
   notify: "restart sshd service"
 
 - name: disable x11 forwarding
@@ -29,6 +32,7 @@
     regexp: "^\\s*#?\\s*X11Forwarding\\s+.*$"
     line: "X11Forwarding no"
     state: present
+    validate: /usr/sbin/sshd -t -f %s
   notify: "restart sshd service"
 
 - name: disable ssh-agent forwarding
@@ -37,6 +41,7 @@
     regexp: "^\\s*#?\\s*AllowAgentForwarding\\s+.*$"
     line: "AllowAgentForwarding no"
     state: present
+    validate: /usr/sbin/sshd -t -f %s
   notify: "restart sshd service"
 
 - name: disable unix-domain socket forwarding
@@ -45,6 +50,7 @@
     regexp: "^\\s*#?\\s*AllowStreamLocalForwarding\\s+.*$"
     line: "AllowStreamLocalForwarding no"
     state: present
+    validate: /usr/sbin/sshd -t -f %s
   notify: "restart sshd service"
 
 - name: set authentication methods to publickey
@@ -53,4 +59,5 @@
     regexp: "^\\s*#?\\s*AuthenticationMethods\\s+.*$"
     line: "AuthenticationMethods publickey"
     state: present
+    validate: /usr/sbin/sshd -t -f %s
   notify: "restart sshd service"

--- a/ansible/roles/firewall/tasks/main.yaml
+++ b/ansible/roles/firewall/tasks/main.yaml
@@ -62,7 +62,7 @@
   community.general.ufw:
     rule: allow
     from_ip: "{{ firewall_docker_bridge_subnet }}"
-    to_ip: 100.0.0.0/8
+    to_ip: 100.64.0.0/10
   when: firewall_docker_bridge_subnet is defined
   notify: reload ufw
 

--- a/ansible/roles/unifi/tasks/main.yaml
+++ b/ansible/roles/unifi/tasks/main.yaml
@@ -22,6 +22,8 @@
   ansible.builtin.get_url:
     url: "{{ unifi_os_server_download_url }}"
     dest: "{{ unifi_os_server_installer_path }}"
+    # update checksum whenever unifi_os_server_download_url changes
+    checksum: "sha256:db17656f222d371da5f96ed104e33503be16ca755817f126409b67d8009b1419"
     mode: "0755"
 
 - name: install UniFi OS Server


### PR DESCRIPTION
## Finding (security review — Medium)

Several Ansible hygiene gaps: `host_key_checking = False` globally (MITM-tolerant on every connection), seven sshd_config `lineinfile` edits with no `validate:` (a bad edit could lock out SSH), `ansible.posix` used by the common role but missing from `requirements.yaml`, the UniFi OS Server installer downloaded with no checksum and executed as root, and a firewall rule using `100.0.0.0/8` where Tailscale's CGNAT range is `100.64.0.0/10`.

## Changes

- `ansible.cfg`: host key checking restored to default (strict); `[ssh_connection] ssh_args` adds `StrictHostKeyChecking=accept-new` while preserving ansible's default args — first connections to new VMs auto-accept and record the key, subsequent connections are strict.
- `roles/common/tasks/ssh.yaml`: every sshd_config edit now runs `validate: /usr/sbin/sshd -t -f %s` so an invalid config is never written.
- `requirements.yaml`: `ansible.posix` added.
- `roles/unifi`: installer pinned to `sha256:db17656f...` (computed from the live 5.0.8 download; verified valid x86-64 ELF, size matched Content-Length). Checksum must be updated alongside the URL.
- `roles/firewall`: docker-bridge-to-tailscale rule narrowed to `100.64.0.0/10`.

## Caveats

- Hosts previously connected without key recording may need a one-time `ssh-keygen -R <host>` if a stale known_hosts entry conflicts; re-provisioned VMs reusing an IP will fail until their old entry is purged (that's the MITM protection working).
- If Ubiquiti silently re-publishes the same installer URL, the play now fails loudly instead of executing changed code as root — intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
