### PR TITLE
fix(terraform): verify cloud image checksums in template builds

### DIFF
--- a/terraform/scripts/build-arch-template.sh
+++ b/terraform/scripts/build-arch-template.sh
@@ -5,6 +5,7 @@ VMID=9002
 NAME=arch-cloud
 IMG=Arch-Linux-x86_64-cloudimg.qcow2
 URL=https://geo.mirror.pkgbuild.com/images/latest/${IMG}
+SUM_URL=${URL}.SHA256
 
 if qm status "${VMID}" >/dev/null 2>&1; then
   echo "Template ${VMID} already exists; nothing to do."
@@ -12,8 +13,20 @@ if qm status "${VMID}" >/dev/null 2>&1; then
 fi
 
 cd /var/lib/vz/template/iso
+DOWNLOADED=0
 if [ ! -f "${IMG}" ]; then
   wget -q "${URL}"
+  DOWNLOADED=1
+fi
+
+# Checksum comes from the same mirror as the moving "latest" image, so this mainly protects download integrity.
+SUM_LINE=$(wget -qO- "${SUM_URL}" | grep " ${IMG}\$")
+if ! echo "${SUM_LINE}" | sha256sum --check --status -; then
+  echo "ERROR: SHA256 verification failed for ${IMG}" >&2
+  if [ "${DOWNLOADED}" -eq 1 ]; then
+    rm -f "${IMG}"
+  fi
+  exit 1
 fi
 
 qm create "${VMID}" --name "${NAME}" --memory 1024 --cores 2 --net0 virtio,bridge=vmbr0 --scsihw virtio-scsi-single --ostype l26 --agent 1

--- a/terraform/scripts/build-ubuntu-template.sh
+++ b/terraform/scripts/build-ubuntu-template.sh
@@ -5,6 +5,7 @@ VMID=9003
 NAME=ubuntu-server-24-04-clean
 IMG=noble-server-cloudimg-amd64.img
 URL=https://cloud-images.ubuntu.com/noble/current/${IMG}
+SUMS_URL=https://cloud-images.ubuntu.com/noble/current/SHA256SUMS
 SNIPPET=ubuntu-template-builder.yml
 
 if qm status "${VMID}" >/dev/null 2>&1; then
@@ -13,8 +14,20 @@ if qm status "${VMID}" >/dev/null 2>&1; then
 fi
 
 cd /var/lib/vz/template/iso
+DOWNLOADED=0
 if [ ! -f "${IMG}" ]; then
   wget -q "${URL}"
+  DOWNLOADED=1
+fi
+
+# Checksum comes from the same dir as the moving "current" image, so this mainly protects download integrity.
+SUM_LINE=$(wget -qO- "${SUMS_URL}" | grep " [*]${IMG}\$")
+if ! echo "${SUM_LINE}" | sha256sum --check --status -; then
+  echo "ERROR: SHA256 verification failed for ${IMG}" >&2
+  if [ "${DOWNLOADED}" -eq 1 ]; then
+    rm -f "${IMG}"
+  fi
+  exit 1
 fi
 
 mkdir -p /var/lib/vz/snippets


### PR DESCRIPTION
## Finding (security review — Medium)

`terraform/scripts/build-ubuntu-template.sh` and `build-arch-template.sh` fetch cloud images with `wget` and no integrity verification, then build Proxmox VM templates from them as root. A corrupted or tampered download would propagate into every VM cloned from the template.

## Changes

- Ubuntu: fetches `SHA256SUMS` from the same release directory and verifies the image with `sha256sum --check`.
- Arch: verifies against the `${URL}.SHA256` file (confirmed live with HTTP 200; `SHA256SUMS` does not exist for that mirror path).
- Verification runs even when the image is already cached locally, catching stale/corrupt files; a just-downloaded image is removed on mismatch and the script exits 1. A missing/empty checksum line also fails closed via `set -e`.

Because both images are moving "current"/"latest" targets, the checksum necessarily comes from the same mirror — this protects download integrity rather than providing an independent trust anchor (noted inline).

`bash -n` and shellcheck clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
