### PR TITLE
fix(talos): enforce PodSecurity defaults and fix archived manifest typos

### DIFF
--- a/kubernetes/archive/apps/default/jellyfin/deployment.yaml
+++ b/kubernetes/archive/apps/default/jellyfin/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: jellyfin
@@ -13,8 +15,6 @@ spec:
       labels:
         app: jellyfin
     spec:
-      strategy:
-        type: Recreate
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -43,7 +43,7 @@ spec:
             timeoutSeconds: 1
             failureThreshold: 3
           securityContext:
-            allowPriviligeEscalation: false
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/kubernetes/archive/apps/default/prowlarr/deployment.yaml
+++ b/kubernetes/archive/apps/default/prowlarr/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: prowlarr
@@ -13,8 +15,6 @@ spec:
       labels:
         app: prowlarr
     spec:
-      strategy:
-        type: Recreate
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -46,7 +46,7 @@ spec:
             timeoutSeconds: 1
             failureThreshold: 3
           securityContext:
-            allowPriviligeEscalation: false
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - NET_RAW

--- a/kubernetes/archive/apps/default/sonarr/deployment.yaml
+++ b/kubernetes/archive/apps/default/sonarr/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sonarr
@@ -13,8 +15,6 @@ spec:
       labels:
         app: sonarr
     spec:
-      strategy:
-        type: Recreate
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -46,7 +46,7 @@ spec:
             timeoutSeconds: 1
             failureThreshold: 3
           securityContext:
-            allowPriviligeEscalation: false
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - NET_RAW

--- a/talos/controlplane-patch.yaml
+++ b/talos/controlplane-patch.yaml
@@ -25,11 +25,20 @@ cluster:
     admissionControl:
       - name: PodSecurity
         configuration:
-          apiVersion: pod-security.admission.config.k8s.io/v1beta1
+          apiVersion: pod-security.admission.config.k8s.io/v1
           kind: PodSecurityConfiguration
+          defaults:
+            enforce: baseline
+            enforce-version: latest
+            audit: restricted
+            audit-version: latest
+            warn: restricted
+            warn-version: latest
           exemptions:
             namespaces:
               - openebs
+              # Cilium (installed via inlineManifests below) needs privileged capabilities
+              - kube-system
   network:
     cni:
       name: none


### PR DESCRIPTION
## Finding (security review — Medium)

The Talos PodSecurity admission configuration declared `exemptions` but no `defaults`, so PSA enforced nothing cluster-wide. Separately, three archived Deployments carried a misspelled `allowPriviligeEscalation` (silently ignored by the API server) and a `strategy:` block nested under the pod spec where it does nothing.

The cluster is currently parked — these are config-only fixes so it comes back safe.

## Changes

- `talos/controlplane-patch.yaml`: added `defaults` (enforce `baseline`, audit/warn `restricted`, all `latest`); `kube-system` added to the exemptions alongside `openebs` since Cilium is installed there via the inline manifest and needs privileged capabilities; `apiVersion` bumped `v1beta1` → `v1` (GA since k8s 1.25; nothing in the repo pins older, and talosctl 1.13.x pairs with k8s ≥1.30). Validated against the Talos schema with `talosctl validate`.
- `kubernetes/archive/apps/default/{jellyfin,prowlarr,sonarr}/deployment.yaml`: `allowPriviligeEscalation` → `allowPrivilegeEscalation`; `strategy: {type: Recreate}` moved from `spec.template.spec` to Deployment `spec`.

A repo-wide grep confirms zero remaining occurrences of the typo; the active `linkding` deployment already had `strategy` placed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
