### PR TITLE
fix(traefik): remove proxmox route unreachable across SRV->MGMT boundary

### DIFF
--- a/docker/init/traefik-dynamic.yml
+++ b/docker/init/traefik-dynamic.yml
@@ -24,19 +24,10 @@ tls:
         - CurveP384
 http:
   serversTransports:
-    # only for proxmox/truenas backends with self-signed certs; never global
+    # only for the truenas backend with a self-signed cert; never global
     insecure-internal:
       insecureSkipVerify: true
   routers:
-    proxmox:
-      entryPoints:
-        - "websecure"
-      rule: "Host(`proxmox.local.elmurphy.com`)"
-      middlewares:
-        - default-headers
-        - https-redirectscheme
-      tls: {}
-      service: proxmox
     truenas:
       entryPoints:
         - "websecure"
@@ -47,12 +38,6 @@ http:
       tls: {}
       service: truenas
   services:
-    proxmox:
-      loadBalancer:
-        servers:
-          - url: "https://10.77.1.100:8006"
-        passHostHeader: true
-        serversTransport: insecure-internal
     truenas:
       loadBalancer:
         servers:


### PR DESCRIPTION
## Context

After #1525 deployed, verification showed `proxmox.local.elmurphy.com` returning 504 — docker-host (SRV VLAN) cannot reach `10.77.1.100:8006` (MGMT) at the TCP level, so the route has been dead since the VLAN segmentation policy landed. Proxmox is reached directly via MGMT/Tailscale instead.

## Changes

- Removed the `proxmox` router and service from `traefik-dynamic.yml`; `truenas` keeps the `insecure-internal` serversTransport (comment updated).

If SRV→MGMT access is ever opened in the #1446 rollout work, the route can be restored from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)