### PR TITLE
fix(firewall): drop vestigial docker-bridge-to-tailscale rule

### DIFF
--- a/ansible/group_vars/docker.yaml
+++ b/ansible/group_vars/docker.yaml
@@ -7,9 +7,6 @@ swap_mode: file
 swap_size_gb: 4
 swap_swappiness: 10
 
-# enables the firewall rule letting the compose bridge reach Tailscale
-firewall_docker_bridge_subnet: 172.20.1.0/24
-
 # enables DOCKER-USER filtering (see roles/firewall); docker-published ports
 # not listed here are dropped
 firewall_docker_allowed_ports:

--- a/ansible/roles/firewall/tasks/main.yaml
+++ b/ansible/roles/firewall/tasks/main.yaml
@@ -58,16 +58,6 @@
     - flush docker-user chain
     - reload ufw
 
-# docker-host only: lets the compose bridge reach the Tailscale CGNAT range.
-# Enabled by setting firewall_docker_bridge_subnet in group vars.
-- name: allow internal docker bridge to tailscale
-  community.general.ufw:
-    rule: allow
-    from_ip: "{{ firewall_docker_bridge_subnet }}"
-    to_ip: 100.64.0.0/10
-  when: firewall_docker_bridge_subnet is defined
-  notify: reload ufw
-
 - name: deny ssh traffic outside of tailscale
   community.general.ufw:
     rule: allow


### PR DESCRIPTION
## Context

While verifying the #1526 rollout, packet-counter analysis showed this rule never gated what its comment claims: `ufw allow from <bridge> to 100.64.0.0/10` without `route: true` creates an INPUT rule, while container→tailnet *forwarded* traffic is accepted by tailscale's `ts-forward` chain before ufw user rules are consulted. No compose file references any tailnet IP, so there is no consumer either way.

## Changes

- Removed the `allow internal docker bridge to tailscale` task from the firewall role and the `firewall_docker_bridge_subnet` var that enabled it.

## Deploy note

Ansible does not remove rules it no longer manages; the live `100.64.0.0/10 ALLOW from 172.20.1.0/24` rule on docker-host is deleted manually alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)