### PR TITLE
chore(flake): bump nixpkgs 0.2511 to 0.2605

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769741972,
-        "narHash": "sha256-RxSg1EioTWNpoLaykiT1UQKTo/K0PPdLqCyQgNjNqWs=",
-        "rev": "63590ac958a8af30ebd52c7a0309d8c52a94dd77",
-        "revCount": 906800,
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "revCount": 1005841,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.906800%2Brev-63590ac958a8af30ebd52c7a0309d8c52a94dd77/019c1a4c-d120-7655-82fa-9c46997dfb5f/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2605.1005841%2Brev-bd0ff2d3eac24699c3664d5966b9ef36f388e2ca/019ea877-a51e-7d63-a6c5-85b9b069aa6c/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2511.903775"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2605.1005841"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Homelab development environment";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2511.903775";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2605.1005841";
   };
 
   outputs = {


### PR DESCRIPTION
~4 months of nixpkgs drift, committed separately from feature work per review guidance.

Verified locally on aarch64-darwin: `nix flake check` passes; dev shell smoke-tested — terraform 1.14.0→1.15.3, ansible-core 2.19.4→2.21.0, talosctl 1.11.5→1.13.3, kubectl 1.34.3→1.36.1, just 1.43.1→1.51.0, all functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)