### PR TITLE
fix(docker): healthchecks, exact version tags, and compose hygiene

### DIFF
--- a/docker/audiobookshelf/compose.yml
+++ b/docker/audiobookshelf/compose.yml
@@ -20,7 +20,7 @@ services:
         bind:
           propagation: rslave
       - audiobookshelf-data:/config
-      - audiobookshelf-data:/metadata
+      - audiobookshelf-metadata:/metadata
     labels:
       - traefik.enable=true
       - traefik.http.routers.audiobookshelf.rule=Host(`audiobookshelf.local.elmurphy.com`)
@@ -36,6 +36,8 @@ services:
 volumes:
   audiobookshelf-data:
     name: audiobookshelf-data
+  audiobookshelf-metadata:
+    name: audiobookshelf-metadata
 
 networks:
   proxy:

--- a/docker/beszel/compose.yml
+++ b/docker/beszel/compose.yml
@@ -18,6 +18,12 @@ services:
       - traefik.http.routers.beszel.rule=Host(`beszel.local.elmurphy.com`)
       - traefik.http.routers.beszel.tls=true
       - traefik.http.services.beszel.loadbalancer.server.port=8090
+    healthcheck:
+      test: ["CMD", "/beszel", "health", "--url", "http://127.0.0.1:8090"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker/couchdb/compose.yml
+++ b/docker/couchdb/compose.yml
@@ -26,7 +26,7 @@ services:
       - traefik.http.middlewares.obsidiancors.headers.accesscontrolalloworiginlist=app://obsidian.md,capacitor://localhost,http://localhost
       - traefik.http.middlewares.obsidiancors.headers.accesscontrolmaxage=3600
       - traefik.http.middlewares.obsidiancors.headers.addvaryheader=true
-      - traefik.http.middlewares.obsidiancors.headers.accessControlAllowCredentials=true
+      - traefik.http.middlewares.obsidiancors.headers.accesscontrolallowcredentials=true
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:5984/_up"]
       interval: 30s

--- a/docker/immich/compose.yml
+++ b/docker/immich/compose.yml
@@ -21,8 +21,10 @@ services:
       - traefik.http.routers.immich.tls=true
       - traefik.http.services.immich.loadbalancer.server.port=2283
     depends_on:
-      - redis
-      - database
+      redis:
+        condition: service_healthy
+      database:
+        condition: service_started # immich postgres image ships no healthcheck
     restart: unless-stopped
     healthcheck:
       disable: false
@@ -41,7 +43,7 @@ services:
       disable: false
 
   redis:
-    image: docker.io/valkey/valkey:9@sha256:546304417feac0874c3dd576e0952c6bb8f06bb4093ea0c9ca303c73cf458f63
+    image: docker.io/valkey/valkey:9.0.1@sha256:546304417feac0874c3dd576e0952c6bb8f06bb4093ea0c9ca303c73cf458f63
     container_name: immich-redis
     security_opt:
       - no-new-privileges:true

--- a/docker/init/compose.yml
+++ b/docker/init/compose.yml
@@ -71,19 +71,14 @@ services:
       - 80:80
       - 443:443
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.traefik.entrypoints=web"
-      - "traefik.http.routers.traefik.rule=Host(`traefik.local.elmurphy.com`)"
-      - "traefik.http.middlewares.traefik-https-redirect.redirectscheme.scheme=web"
-      - "traefik.http.middlewares.sslheader.headers.customrequestheaders.X-Forwarded-Proto=https"
-      - "traefik.http.routers.traefik.middlewares=traefik-https-redirect"
-      - "traefik.http.routers.traefik-secure.entrypoints=websecure"
-      - "traefik.http.routers.traefik-secure.rule=Host(`traefik.local.elmurphy.com`)"
-      - "traefik.http.routers.traefik-secure.tls=true"
-      - "traefik.http.routers.traefik-secure.tls.certresolver=cloudflare"
-      - "traefik.http.routers.traefik-secure.tls.domains[0].main=local.elmurphy.com"
-      - "traefik.http.routers.traefik-secure.tls.domains[0].sans=*.local.elmurphy.com"
-      - "traefik.http.routers.traefik-secure.service=api@internal"
+      - traefik.enable=true
+      - traefik.http.routers.traefik-secure.entrypoints=websecure
+      - traefik.http.routers.traefik-secure.rule=Host(`traefik.local.elmurphy.com`)
+      - traefik.http.routers.traefik-secure.tls=true
+      - traefik.http.routers.traefik-secure.tls.certresolver=cloudflare
+      - traefik.http.routers.traefik-secure.tls.domains[0].main=local.elmurphy.com
+      - traefik.http.routers.traefik-secure.tls.domains[0].sans=*.local.elmurphy.com
+      - traefik.http.routers.traefik-secure.service=api@internal
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
       interval: 30s

--- a/docker/init/traefik-dynamic.yml
+++ b/docker/init/traefik-dynamic.yml
@@ -1,6 +1,7 @@
 ---
 tls:
   options:
+    # opt-in via tls.options=modern@file
     modern:
       minVersion: VersionTLS13
       sniStrict: true
@@ -8,7 +9,8 @@ tls:
         - X25519
         - CurveP256
         - CurveP384
-    intermediate:
+    # applied automatically to every TLS router without explicit tls.options
+    default:
       cipherSuites:
         - "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
         - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"

--- a/docker/jellyfin/compose.yml
+++ b/docker/jellyfin/compose.yml
@@ -13,7 +13,7 @@ services:
     devices:
       - /dev/dri:/dev/dri
     group_add:
-      - 992 # render group 
+      - 992 # render group
     environment:
       - JELLYFIN_PublishedServerUrl=https://jellyfin.local.elmurphy.com
     volumes:
@@ -31,15 +31,22 @@ services:
         read_only: true
         bind:
           propagation: rslave
-      - /dev/shm:/transcode # ram transcode
+    tmpfs:
+      - /transcode # ram transcode
     ports:
-      - 8096:8096 
+      # deliberate direct LAN access; allowlisted in firewall_docker_allowed_ports
+      - 8096:8096
     labels:
       - traefik.enable=true
       - traefik.http.routers.jellyfin.rule=Host(`jellyfin.local.elmurphy.com`)
       - traefik.http.routers.jellyfin.tls=true
       - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-      - traefik.http.routers.jellyfin.tls.options=intermediate@file
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8096/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker/miniflux/compose.yml
+++ b/docker/miniflux/compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   miniflux:
     image: miniflux/miniflux:2.3.1@sha256:42f14382a035e9d9bbc33910ca53f72d47177f75c3c638d2c5a85adf5582d538

--- a/docker/owncloud/compose.yml
+++ b/docker/owncloud/compose.yml
@@ -38,8 +38,10 @@ services:
       - traefik.http.routers.owncloud.tls=true
       - traefik.http.services.owncloud.loadbalancer.server.port=8080
     depends_on:
-      - owncloud-mariadb
-      - owncloud-redis
+      owncloud-mariadb:
+        condition: service_healthy
+      owncloud-redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/bin/healthcheck"]
       interval: 30s
@@ -80,7 +82,7 @@ services:
     restart: unless-stopped
 
   owncloud-redis:
-    image: redis:8@sha256:aa049e689e141a4358ad1d4562dc49c88a89fbab711fd8fcc33f684c80b26301
+    image: redis:8.8.0@sha256:aa049e689e141a4358ad1d4562dc49c88a89fbab711fd8fcc33f684c80b26301
     container_name: owncloud-redis
     security_opt:
       - no-new-privileges:true

--- a/docker/pinchflat/compose.yml
+++ b/docker/pinchflat/compose.yml
@@ -23,6 +23,12 @@ services:
       - traefik.http.routers.pinchflat.rule=Host(`pinchflat.local.elmurphy.com`)
       - traefik.http.routers.pinchflat.tls=true
       - traefik.http.services.pinchflat.loadbalancer.server.port=8945
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8945/healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker/plex/compose.yml
+++ b/docker/plex/compose.yml
@@ -30,11 +30,13 @@ services:
       - type: bind
         source: /mnt/data/media
         target: /data/media
+        read_only: true
         bind:
           propagation: rslave
       - type: bind
         source: /mnt/music
         target: /data/music
+        read_only: true
         bind:
           propagation: rslave
     labels:
@@ -42,6 +44,12 @@ services:
       - traefik.http.routers.plex.rule=Host(`plex.local.elmurphy.com`)
       - traefik.http.routers.plex.tls=true
       - traefik.http.services.plex.loadbalancer.server.port=32400
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:32400/identity"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   tautulli:
@@ -120,6 +128,7 @@ services:
       - proxy
     volumes:
       - kometa-data:/config:rw
+    # no healthcheck: kometa is a scheduled batch job, not a long-running server
     restart: unless-stopped
 
 volumes:

--- a/docker/wallabag/compose.yml
+++ b/docker/wallabag/compose.yml
@@ -37,13 +37,21 @@ services:
       - traefik.http.routers.wallabag.rule=Host(`wallabag.local.elmurphy.com`)
       - traefik.http.routers.wallabag.tls=true
       - traefik.http.services.wallabag.loadbalancer.server.port=80
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1/api/info"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
 
   db:
-    image: mariadb@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b
+    image: mariadb:12.3.2@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b
     container_name: wallabag-mariadb
     security_opt:
       - no-new-privileges:true
@@ -69,7 +77,7 @@ services:
     restart: unless-stopped
 
   redis:
-    image: redis:alpine@sha256:09160599abd229764c0fb44cb6be640294e1d360a54b19985ab4843dcf2d90f1
+    image: redis:8.8.0-alpine@sha256:09160599abd229764c0fb44cb6be640294e1d360a54b19985ab4843dcf2d90f1
     container_name: wallabag-redis
     security_opt:
       - no-new-privileges:true
@@ -88,7 +96,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
       interval: 20s
       timeout: 3s
-    restart: unless-stopped    
+    restart: unless-stopped
 
 volumes:
   wallabag-data:


### PR DESCRIPTION
## Review findings (Low/Nit tier)

- **Healthchecks** added to beszel (`/beszel health` — scratch image, no shell tools), pinchflat (`/healthcheck`), jellyfin (`/health`), plex (`/identity`), wallabag (`/api/info`); endpoints and curl availability verified against each pinned image. kometa gets a comment instead — it's a scheduled batch job.
- **`depends_on` → `condition: service_healthy`** where the dependency has a healthcheck (wallabag db/redis, owncloud mariadb/redis, immich redis). Immich's postgres stays `service_started` — that image defines no healthcheck.
- **Exact version tags** restored on digest-pinned images (digests unchanged, resolved via Docker Hub): `valkey:9→9.0.1`, `postgres:18→18.4`, `redis:8→8.8.0`, `redis:alpine→8.8.0-alpine`, wallabag's untagged mariadb → `12.3.2`.
- **Plex media/music binds read-only**; jellyfin's host `/dev/shm` bind replaced with a tmpfs at `/transcode`; jellyfin's 8096 publish kept with a comment (deliberately allowlisted in `firewall_docker_allowed_ports`).
- **Audiobookshelf `/metadata` split** into its own `audiobookshelf-metadata` volume (was intermixed with `/config` in one volume — backup/migration hazard).
- **Dead Traefik labels removed** from the init stack (invalid `redirectscheme.scheme=web` router/middleware, unused `sslheader`); label quoting normalized.
- **TLS options**: `intermediate` renamed to `default` so it applies fleet-wide per Traefik v3 semantics; jellyfin's now-redundant per-router option label removed; `modern` stays opt-in.
- Cosmetics: miniflux `---` marker, trailing whitespace, couchdb label casing.

Skipped deliberately: lscr.io→ghcr.io unification (digest churn), YAML-anchor dedup, mem_limit consistency, service renames.

## Deploy notes

Portainer GitOps will recreate ~14 containers including **traefik** (brief proxy blip). **Audiobookshelf requires a one-time host-side metadata migration at deploy** (stop container, copy existing metadata content from the old shared volume into `audiobookshelf-metadata`, restart) — without it ABS comes up with empty metadata/progress. Migration is being handled alongside the merge.

Validation: `yaml.safe_load` + `docker compose config -q` green on all 13 stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
