### PR TITLE
fix(ansible): check-mode support, dead artifact cleanup, local init sync

### DIFF
--- a/ansible/group_vars/docker.yaml
+++ b/ansible/group_vars/docker.yaml
@@ -1,7 +1,6 @@
 ---
 username: mm
 ssh_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8UxcTkHym30wEg6jekF
-docker_users: "{{ username }}"
 
 swap_mode: file
 swap_size_gb: 4

--- a/ansible/group_vars/games.yaml
+++ b/ansible/group_vars/games.yaml
@@ -1,4 +1,0 @@
----
-username: mm
-ssh_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIH1TgAtlovn+B5ojfw7JRFDi8UxcTkHym30wEg6jekF
-docker_users: "{{ username }}"

--- a/ansible/host_vars/ai-dev-bc.yaml
+++ b/ansible/host_vars/ai-dev-bc.yaml
@@ -1,9 +1,0 @@
----
-git_user_name: "Michael Murphy"
-git_user_email: "{{ ai_dev_git_user_emails[inventory_hostname] }}"
-
-# Encrypt secrets below with: ansible-vault encrypt_string --name '<key>' '<value>'
-# gh_token: !vault | ...
-# Choose ONE Claude auth method:
-# claude_credentials_json: !vault | ...   (contents of a logged-in ~/.claude/.credentials.json)
-# anthropic_api_key: !vault | ...

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,8 +1,11 @@
 ---
 collections:
-  - ansible.posix
-  - community.general
-  - kewlfft.aur
+  - name: ansible.posix
+    version: ">=2.1.0"
+  - name: community.general
+    version: ">=12.0.0"
+  - name: kewlfft.aur
+    version: ">=0.13.0"
   # MikroTik RouterOS API (routeros role)
   - name: community.routeros
     version: ">=3.20.0"

--- a/ansible/roles/ai-dev/tasks/accounts.yaml
+++ b/ansible/roles/ai-dev/tasks/accounts.yaml
@@ -32,11 +32,9 @@
   when: gh_token is defined
 
 - name: Authenticate gh CLI with token
-  ansible.builtin.shell: >
-    set -o pipefail &&
-    echo '{{ gh_token }}' | gh auth login --hostname github.com --git-protocol ssh --with-token
-  args:
-    executable: /bin/bash
+  ansible.builtin.command:
+    cmd: gh auth login --hostname github.com --git-protocol ssh --with-token
+    stdin: "{{ gh_token }}"
   become_user: "{{ username }}"
   when:
     - gh_token is defined

--- a/ansible/roles/common/tasks/swap-file.yaml
+++ b/ansible/roles/common/tasks/swap-file.yaml
@@ -28,11 +28,13 @@
   ansible.builtin.set_fact:
     root_fstype: "{{ (ansible_mounts | selectattr('mount', 'eq', '/') | list | first).fstype }}"
 
+# read-only query; must run in --check so the swap state below resolves
 - name: list active swap devices
   ansible.builtin.command:
     cmd: swapon --show=NAME --noheadings
   register: active_swaps
   changed_when: false
+  check_mode: false
 
 - name: compute swap state
   ansible.builtin.set_fact:

--- a/ansible/roles/common/tasks/users.yaml
+++ b/ansible/roles/common/tasks/users.yaml
@@ -26,7 +26,7 @@
     state: directory
     owner: "{{ username }}"
     group: "{{ username }}"
-    mode: "0755"
+    mode: "0750"
 
 - name: add authorised ssh key to user
   ansible.posix.authorized_key:

--- a/ansible/roles/docker/defaults/main.yaml
+++ b/ansible/roles/docker/defaults/main.yaml
@@ -8,5 +8,7 @@ docker_image_prune_until: 168h
 docker_image_prune_calendar: weekly
 docker_image_prune_randomized_delay: 1h
 
+srv_dir: /srv/init
+
 pocket_id_encryption_key_dir: /etc/pocket-id
 pocket_id_encryption_key_path: "{{ pocket_id_encryption_key_dir }}/encryption-key"

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,4 +1,22 @@
 ---
+# this role manages compose stacks but deliberately does not install docker
+# (host runs docker-ce; an apt docker.io install would conflict)
+- name: check docker compose availability
+  ansible.builtin.command:
+    cmd: docker compose version
+  register: docker_compose_check
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+- name: assert docker and the compose plugin are installed
+  ansible.builtin.assert:
+    that: docker_compose_check.rc == 0
+    fail_msg: >-
+      docker with the compose plugin is required on {{ inventory_hostname }}
+      but `docker compose version` failed; install docker-ce and the
+      docker-compose-plugin before running this role
+
 - name: ensure Docker daemon config directory exists
   ansible.builtin.file:
     path: /etc/docker
@@ -76,29 +94,12 @@
     enabled: "{{ docker_image_prune_enabled }}"
     state: "{{ 'started' if docker_image_prune_enabled else 'stopped' }}"
 
-- name: set clone directory
-  ansible.builtin.set_fact:
-    clone_dir: /tmp/home-infra
-    srv_dir: "/srv/init"
-
-- name: clone docker repo
-  ansible.builtin.git:
-    repo: "https://github.com/mich-murphy/home-infra.git"
-    dest: "{{ clone_dir }}"
-    depth: 1
-
 - name: sync init compose files
   ansible.builtin.copy:
-    remote_src: true
-    src: "{{ clone_dir }}/docker/init/"
+    src: "{{ playbook_dir }}/../docker/init/"
     dest: "{{ srv_dir }}/"
     owner: "{{ username }}"
     mode: "0775"
-
-- name: delete clone directory
-  ansible.builtin.file:
-    path: "{{ clone_dir }}"
-    state: absent
 
 - name: ensure Pocket ID secret directory exists
   ansible.builtin.file:
@@ -113,11 +114,13 @@
     path: "{{ pocket_id_encryption_key_path }}"
   register: pocket_id_key_file
 
+# side-effect free; runs in --check so the key fact below resolves
 - name: generate Pocket ID encryption key
   ansible.builtin.command:
     cmd: openssl rand -hex 32
   register: generated_pocket_id_key
-  changed_when: true
+  changed_when: false
+  check_mode: false
   when: not pocket_id_key_file.stat.exists
   no_log: true
 
@@ -135,11 +138,17 @@
   ansible.builtin.slurp:
     src: "{{ pocket_id_encryption_key_path }}"
   register: pocket_id_key
+  check_mode: false
+  when: pocket_id_key_file.stat.exists
   no_log: true
 
+# freshly generated key is used directly; in --check the file is never written
 - name: set Pocket ID encryption key fact
   ansible.builtin.set_fact:
-    pocket_id_encryption_key: "{{ pocket_id_key.content | b64decode | trim }}"
+    pocket_id_encryption_key: >-
+      {{ (pocket_id_key.content | b64decode | trim)
+         if pocket_id_key_file.stat.exists
+         else generated_pocket_id_key.stdout }}
   no_log: true
 
 - name: setup .env file

--- a/ansible/roles/firewall/tasks/main.yaml
+++ b/ansible/roles/firewall/tasks/main.yaml
@@ -58,7 +58,8 @@
     - flush docker-user chain
     - reload ufw
 
-- name: deny ssh traffic outside of tailscale
+# ssh stays reachable via the tailscale0 allow rule above
+- name: delete bare 22/tcp allow rule
   community.general.ufw:
     rule: allow
     port: "22"

--- a/ansible/roles/media/defaults/main.yaml
+++ b/ansible/roles/media/defaults/main.yaml
@@ -1,0 +1,29 @@
+---
+nfs_mount_opts: "rw,vers=4.2,proto=tcp,hard,_netdev,x-systemd.automount,x-systemd.idle-timeout=600,nofail"
+
+nfs_mounts:
+  - name: "media"
+    local_path: "/mnt/data"
+    nfs_share: "10.77.20.101:/mnt/slow/media"
+    owner: "media"
+    group: "media"
+  - name: "photos"
+    local_path: "/mnt/photos"
+    nfs_share: "10.77.20.101:/mnt/slow/photos"
+    owner: "photos"
+    group: "photos"
+  - name: "music"
+    local_path: "/mnt/music"
+    nfs_share: "10.77.20.101:/mnt/slow/media/music"
+    owner: "media"
+    group: "media"
+  - name: "audiobooks"
+    local_path: "/mnt/audiobooks"
+    nfs_share: "10.77.20.101:/mnt/slow/media/audiobooks"
+    owner: "media"
+    group: "media"
+
+retired_nfs_mounts:
+  - name: "emulators"
+    local_path: "/mnt/emulators"
+    nfs_share: "10.77.20.101:/mnt/slow/media/emulators"

--- a/ansible/roles/media/tasks/nfs.yaml
+++ b/ansible/roles/media/tasks/nfs.yaml
@@ -5,40 +5,13 @@
       - nfs-common
     state: present
 
-- name: define nfs configurations
-  ansible.builtin.set_fact:
-    nfs_mount_opts: "rw,vers=4.2,proto=tcp,hard,_netdev,x-systemd.automount,x-systemd.idle-timeout=600,nofail"
-    nfs_mounts:
-      - name: "media"
-        local_path: "/mnt/data"
-        nfs_share: "10.77.20.101:/mnt/slow/media"
-        owner: "media"
-        group: "media"
-      - name: "photos"
-        local_path: "/mnt/photos"
-        nfs_share: "10.77.20.101:/mnt/slow/photos"
-        owner: "photos"
-        group: "photos"
-      - name: "music"
-        local_path: "/mnt/music"
-        nfs_share: "10.77.20.101:/mnt/slow/media/music"
-        owner: "media"
-        group: "media"
-      - name: "audiobooks"
-        local_path: "/mnt/audiobooks"
-        nfs_share: "10.77.20.101:/mnt/slow/media/audiobooks"
-        owner: "media"
-        group: "media"
-    retired_nfs_mounts:
-      - name: "emulators"
-        local_path: "/mnt/emulators"
-        nfs_share: "10.77.20.101:/mnt/slow/media/emulators"
-
+# read-only query; must run in --check so the unmount loop below resolves
 - name: check retired nfs mount state
   ansible.builtin.command:
     cmd: "findmnt -rn --target {{ item.local_path }}"
   register: retired_nfs_mount_state
   changed_when: false
+  check_mode: false
   failed_when: retired_nfs_mount_state.rc not in [0, 1]
   loop: "{{ retired_nfs_mounts }}"
   loop_control:
@@ -101,11 +74,13 @@
     (retired_nfs_fstab_results is changed)
     or (active_nfs_fstab_results is changed)
 
+# read-only query; must run in --check so the mount loop below resolves
 - name: check active nfs mount state
   ansible.builtin.command:
     cmd: "findmnt -rn --target {{ item.local_path }}"
   register: active_nfs_mount_state
   changed_when: false
+  check_mode: false
   failed_when: active_nfs_mount_state.rc not in [0, 1]
   loop: "{{ nfs_mounts }}"
   loop_control:

--- a/ansible/roles/unifi/handlers/main.yaml
+++ b/ansible/roles/unifi/handlers/main.yaml
@@ -1,5 +1,0 @@
----
-- name: restart unifi
-  ansible.builtin.systemd:
-    name: unifi
-    state: restarted

--- a/ansible/run.yaml
+++ b/ansible/run.yaml
@@ -1,5 +1,6 @@
 ---
-- hosts: docker
+- name: configure docker hosts
+  hosts: docker
   become: true
   vars_files:
     - "group_vars/secrets.yaml"
@@ -9,7 +10,8 @@
     - media
     - docker
 
-- hosts: ai-dev
+- name: configure ai-dev hosts
+  hosts: ai-dev
   become: true
   vars_files:
     - "group_vars/secrets.yaml"
@@ -17,7 +19,8 @@
     - common
     - ai-dev
 
-- hosts: unifi
+- name: configure unifi controller
+  hosts: unifi
   become: true
   vars_files:
     - "group_vars/secrets.yaml"
@@ -28,7 +31,8 @@
 
 # RB5009 config is pushed over the RouterOS API from localhost (no SSH/become);
 # connection params injected here via module_defaults, credentials from the vault.
-- hosts: routeros
+- name: configure routeros gateway
+  hosts: routeros
   gather_facts: false
   vars_files:
     - "group_vars/secrets.yaml"
@@ -39,6 +43,7 @@
       password: "{{ routeros_api_password }}"
       port: "{{ routeros_api_port | default(omit) }}"
       tls: "{{ routeros_api_tls | default(true) }}"
+      # accepted risk: self-signed router cert, API reachable only on the MGMT VLAN
       validate_certs: false
   roles:
     - routeros


### PR DESCRIPTION
## Review findings (Low/Nit tier)

- **`--check` support**: read-only command/slurp tasks in the common (swap), media (nfs), and docker (Pocket ID key) roles annotated `check_mode: false` / `changed_when: false` mirroring the routeros role's pattern; the Pocket ID slurp is gated so check mode works on fresh and converged hosts.
- **Dead artifacts deleted** (each verified unused by repo-wide grep): `group_vars/games.yaml` (no `[games]` group), `host_vars/ai-dev-bc.yaml` (host not in inventory), `docker_users` var (consumed by nothing), and the unifi handler restarting a nonexistent `unifi` unit (service is `uosserver`, started directly by tasks; nothing notified the handler).
- **docker role simplification**: the target no longer shallow-clones the repo from GitHub — `/srv/init` is copied directly from the control machine's checkout (`playbook_dir`-relative), which is per-file checksum-idempotent and eliminates the cosmetic always-`changed` reporting from the old `remote_src` directory copy. Constants moved to role defaults. New fail-fast assert that docker + compose plugin exist (no install task — host runs docker-ce; an apt task would conflict).
- **gh token off argv**: `gh auth login --with-token` via module `stdin` (token was briefly visible in /proc cmdline).
- Management user home `0755 → 0750`; routeros `validate_certs: false` documented as accepted risk; media NFS mount data moved from `set_fact` to role defaults (overridable); plays named; misleading firewall task renamed; collections version-pinned from installed versions.

Skipped deliberately: `ansible.posix.mount` rewrite of the NFS logic (risky on live mounts), NOPASSWD sudo (conscious choice per review).

## Deploy notes

Next `just run docker-host`: home-mode and possibly one-time copy-attribute `changed`s, then steady-state runs report changed only on real diffs (plus the deliberate always-changed compose task). Runs are faster — no GitHub clone from the target. Syntax check passes with the vault (`ansible-playbook run.yaml --syntax-check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
