### PR TITLE
feat(kubernetes): nfs volumes, namespaces, intel gpu plugin, volsync

### DIFF
--- a/kubernetes/infrastructure/configs/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespaces
   - external-secrets
   - cert-manager
   - gateway
+  - storage

--- a/kubernetes/infrastructure/configs/namespaces/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/namespaces/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespaces.yaml

--- a/kubernetes/infrastructure/configs/namespaces/namespaces.yaml
+++ b/kubernetes/infrastructure/configs/namespaces/namespaces.yaml
@@ -1,0 +1,22 @@
+# Workload namespaces, grouped by stack. All run under the cluster-wide
+# baseline PSA; namespaces needing privileged opt in via label next to the
+# workload that requires it.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: media
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: immich
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tools
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth

--- a/kubernetes/infrastructure/configs/storage/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/storage/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfs-media.yaml

--- a/kubernetes/infrastructure/configs/storage/nfs-media.yaml
+++ b/kubernetes/infrastructure/configs/storage/nfs-media.yaml
@@ -1,0 +1,141 @@
+# Static binding to the existing TrueNAS exports (mirrors the docker-host
+# fstab mounts). Capacities are nominal — NFS does not enforce them.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-media
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.2
+    - hard
+  nfs:
+    server: 10.77.20.101
+    path: /mnt/slow/media
+  claimRef:
+    namespace: media
+    name: nfs-media
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-media
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: nfs-media
+  resources:
+    requests:
+      storage: 1Ti
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-music
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.2
+    - hard
+  nfs:
+    server: 10.77.20.101
+    path: /mnt/slow/media/music
+  claimRef:
+    namespace: media
+    name: nfs-music
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-music
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: nfs-music
+  resources:
+    requests:
+      storage: 500Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-audiobooks
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.2
+    - hard
+  nfs:
+    server: 10.77.20.101
+    path: /mnt/slow/media/audiobooks
+  claimRef:
+    namespace: media
+    name: nfs-audiobooks
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-audiobooks
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: nfs-audiobooks
+  resources:
+    requests:
+      storage: 500Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-photos
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.2
+    - hard
+  nfs:
+    server: 10.77.20.101
+    path: /mnt/slow/photos
+  claimRef:
+    namespace: immich
+    name: nfs-photos
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-photos
+  namespace: immich
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: nfs-photos
+  resources:
+    requests:
+      storage: 500Gi

--- a/kubernetes/infrastructure/controllers/intel-device-plugins/daemonset.yaml
+++ b/kubernetes/infrastructure/controllers/intel-device-plugins/daemonset.yaml
@@ -1,0 +1,72 @@
+# Plain DaemonSet (no operator/NFD — single node, nothing to discover).
+# Exposes gpu.intel.com/i915; shared-dev-num lets plex, jellyfin and
+# immich-server share the one iGPU.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-plugin
+  namespace: intel-device-plugins
+spec:
+  selector:
+    matchLabels:
+      app: intel-gpu-plugin
+  template:
+    metadata:
+      labels:
+        app: intel-gpu-plugin
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: intel-gpu-plugin
+          image: intel/intel-gpu-plugin:0.36.0@sha256:2db679be62b52ac985169084ca711cab6e6c59fe543ab2ddee58163d6f8d29e0
+          args:
+            - -shared-dev-num
+            - "4"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: devfs
+              mountPath: /dev/dri
+              readOnly: true
+            - name: sysfs
+              mountPath: /sys/class/drm
+              readOnly: true
+            - name: kubeletsockets
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: cdi
+              mountPath: /var/run/cdi
+      volumes:
+        - name: devfs
+          hostPath:
+            path: /dev/dri
+        - name: sysfs
+          hostPath:
+            path: /sys/class/drm
+        - name: kubeletsockets
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: cdi
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate

--- a/kubernetes/infrastructure/controllers/intel-device-plugins/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/intel-device-plugins/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - daemonset.yaml

--- a/kubernetes/infrastructure/controllers/intel-device-plugins/namespace.yaml
+++ b/kubernetes/infrastructure/controllers/intel-device-plugins/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intel-device-plugins
+  labels:
+    # hostPath access to /dev/dri and the kubelet socket.
+    pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/infrastructure/controllers/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/kustomization.yaml
@@ -4,4 +4,6 @@ resources:
   - cilium
   - cert-manager
   - external-secrets
+  - intel-device-plugins
   - openebs
+  - volsync

--- a/kubernetes/infrastructure/controllers/volsync/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/volsync/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/kubernetes/infrastructure/controllers/volsync/namespace.yaml
+++ b/kubernetes/infrastructure/controllers/volsync/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volsync-system

--- a/kubernetes/infrastructure/controllers/volsync/release.yaml
+++ b/kubernetes/infrastructure/controllers/volsync/release.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: volsync
+  namespace: volsync-system
+spec:
+  releaseName: volsync
+  interval: 12h
+  chart:
+    spec:
+      chart: volsync
+      version: "0.16.0"
+      sourceRef:
+        kind: HelmRepository
+        name: backube
+        namespace: volsync-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled

--- a/kubernetes/infrastructure/controllers/volsync/repository.yaml
+++ b/kubernetes/infrastructure/controllers/volsync/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: backube
+  namespace: volsync-system
+spec:
+  interval: 24h
+  url: https://backube.github.io/helm-charts/


### PR DESCRIPTION
## Summary
Stacked on #1544.

- **Static NFS PVs/PVCs** (`infrastructure/configs/storage/`): bind the existing TrueNAS exports exactly as docker-host mounts them today (`/mnt/slow/media`→ns `media`, `music`, `audiobooks`, `/mnt/slow/photos`→ns `immich`); `claimRef`-pinned, `nfsvers=4.2,hard`, `Retain`. Fixed exports, no dynamic provisioning → no CSI driver (decision validated by research: csi-driver-nfs/democratic-csi add moving parts for zero benefit here).
- **Workload namespaces** `media`/`immich`/`tools`/`auth` under the cluster baseline PSA.
- **Intel GPU plugin** (`v0.36.0`, digest-pinned): plain DaemonSet — no operator, no NFD on a single node. `-shared-dev-num=4` lets plex, jellyfin and immich-server share `gpu.intel.com/i915`. Namespace labelled privileged (hostPath /dev/dri + kubelet socket).
- **VolSync 0.16.0**: backup controller for the hostpath PVCs (they have zero protection otherwise). Per-app `ReplicationSource`s ship with each app PR — restic repo on a TrueNAS NFS export via the upstream `moverVolumes` NFS support (added in volsync v0.15).

## Verification
kubernetes gate passes for all kustomizations (PV/PVC/DaemonSet against default schemas, HelmRelease against CRDs-catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)