### PR TITLE
feat(kubernetes): plex and jellyfin stacks

### DIFF
--- a/kubernetes/apps/media/jellyfin/deployment.yaml
+++ b/kubernetes/apps/media/jellyfin/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin
+  namespace: media
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: jellyfin
+  template:
+    metadata:
+      labels:
+        app: jellyfin
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        # render group for /dev/dri access (compose group_add).
+        supplementalGroups:
+          - 992
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: jellyfin
+          image: jellyfin/jellyfin:10.11.11@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
+          ports:
+            - containerPort: 8096
+          env:
+            - name: JELLYFIN_PublishedServerUrl
+              value: https://jellyfin.local.elmurphy.com
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8096
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8096
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: cache
+              mountPath: /cache
+            - name: transcode
+              mountPath: /transcode
+            - name: media
+              mountPath: /data/media
+              subPath: media
+              readOnly: true
+            - name: music
+              mountPath: /data/music
+              readOnly: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+              gpu.intel.com/i915: 1
+            limits:
+              memory: 1536Mi
+              gpu.intel.com/i915: 1
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: jellyfin-data
+        - name: cache
+          persistentVolumeClaim:
+            claimName: jellyfin-cache
+        # Disk-backed (compose used tmpfs): node RAM is too scarce for transcode buffers.
+        - name: transcode
+          emptyDir: {}
+        - name: media
+          persistentVolumeClaim:
+            claimName: nfs-media
+        - name: music
+          persistentVolumeClaim:
+            claimName: nfs-music

--- a/kubernetes/apps/media/jellyfin/httproute.yaml
+++ b/kubernetes/apps/media/jellyfin/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyfin
+  namespace: media
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - jellyfin.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: jellyfin
+          port: 8096

--- a/kubernetes/apps/media/jellyfin/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/media/jellyfin/replicationsource.yaml
+++ b/kubernetes/apps/media/jellyfin/replicationsource.yaml
@@ -1,0 +1,53 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jellyfin-data-volsync
+  namespace: media
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/jellyfin-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly config backup to the TrueNAS volsync export. Direct copy is not
+# point-in-time consistent; apps with databases pair this with a dump job.
+# jellyfin-cache is rebuildable and deliberately not backed up.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: jellyfin-data
+  namespace: media
+spec:
+  sourcePVC: jellyfin-data
+  trigger:
+    schedule: "5 4 * * *"
+  restic:
+    repository: jellyfin-data-volsync
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/media/jellyfin/service.yaml
+++ b/kubernetes/apps/media/jellyfin/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin
+  namespace: media
+spec:
+  ports:
+    - port: 8096
+  selector:
+    app: jellyfin

--- a/kubernetes/apps/media/jellyfin/storage.yaml
+++ b/kubernetes/apps/media/jellyfin/storage.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-data
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-cache
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/media/kometa/cronjob.yaml
+++ b/kubernetes/apps/media/kometa/cronjob.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kometa
+  namespace: media
+spec:
+  schedule: "0 5 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: kometa
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: kometa
+              image: kometateam/kometa:v2.3.1@sha256:683c04827ef3fecf1cc5cb178f75f91f968aef6c6d89d34bc9c70966fd1d7259
+              # Run one pass and exit; the CronJob replaces kometa's internal scheduler.
+              args:
+                - --run
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  memory: 768Mi
+          volumes:
+            - name: config
+              persistentVolumeClaim:
+                claimName: kometa-data

--- a/kubernetes/apps/media/kometa/kustomization.yaml
+++ b/kubernetes/apps/media/kometa/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storage.yaml
+  - cronjob.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/media/kometa/replicationsource.yaml
+++ b/kubernetes/apps/media/kometa/replicationsource.yaml
@@ -1,0 +1,53 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kometa-data-volsync
+  namespace: media
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/kometa-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly config backup to the TrueNAS volsync export. Direct copy is not
+# point-in-time consistent; apps with databases pair this with a dump job.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: kometa-data
+  namespace: media
+spec:
+  sourcePVC: kometa-data
+  trigger:
+    schedule: "0 4 * * *"
+  restic:
+    repository: kometa-data-volsync
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    # Kometa's image has no user-drop; config files are root-owned.
+    moverSecurityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      fsGroup: 0
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/media/kometa/storage.yaml
+++ b/kubernetes/apps/media/kometa/storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kometa-data
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -10,3 +10,8 @@ resources:
   - sabnzbd
   - audiobookshelf
   - pinchflat
+  - plex
+  - tautulli
+  - seerr
+  - kometa
+  - jellyfin

--- a/kubernetes/apps/media/plex/deployment.yaml
+++ b/kubernetes/apps/media/plex/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: plex
+  namespace: media
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: plex
+  template:
+    metadata:
+      labels:
+        app: plex
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: plex
+          image: plexinc/pms-docker:1.43.2.10687-563d026ea@sha256:c37106c57fed7a6624f5dee5a3ce460ff011f09a2aa7f4ee9e8dbbd08ae1b87e
+          ports:
+            - containerPort: 32400
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: Australia/Melbourne
+            - name: PLEX_CLAIM
+              valueFrom:
+                secretKeyRef:
+                  name: plex-credentials
+                  key: claim
+                  optional: true
+          livenessProbe:
+            httpGet:
+              path: /identity
+              port: 32400
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /identity
+              port: 32400
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Plex init starts as root and drops to PUID/PGID.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: transcode
+              mountPath: /transcode
+            - name: media
+              mountPath: /data/media
+              subPath: media
+              readOnly: true
+            - name: music
+              mountPath: /data/music
+              readOnly: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+              gpu.intel.com/i915: 1
+            limits:
+              memory: 2Gi
+              gpu.intel.com/i915: 1
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: plex-data
+        - name: transcode
+          emptyDir: {}
+        - name: media
+          persistentVolumeClaim:
+            claimName: nfs-media
+        - name: music
+          persistentVolumeClaim:
+            claimName: nfs-music

--- a/kubernetes/apps/media/plex/httproute.yaml
+++ b/kubernetes/apps/media/plex/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: plex
+  namespace: media
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - plex.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: plex
+          port: 32400

--- a/kubernetes/apps/media/plex/kustomization.yaml
+++ b/kubernetes/apps/media/plex/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storage.yaml
+  - secret.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/media/plex/replicationsource.yaml
+++ b/kubernetes/apps/media/plex/replicationsource.yaml
@@ -1,0 +1,52 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plex-data-volsync
+  namespace: media
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/plex-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly config backup to the TrueNAS volsync export. Direct copy is not
+# point-in-time consistent; apps with databases pair this with a dump job.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: plex-data
+  namespace: media
+spec:
+  sourcePVC: plex-data
+  trigger:
+    schedule: "45 3 * * *"
+  restic:
+    repository: plex-data-volsync
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/media/plex/secret.yaml
+++ b/kubernetes/apps/media/plex/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plex-credentials
+  namespace: media
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+  data:
+    - secretKey: claim
+      remoteRef:
+        key: plex/claim

--- a/kubernetes/apps/media/plex/service.yaml
+++ b/kubernetes/apps/media/plex/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: plex
+  namespace: media
+spec:
+  ports:
+    - port: 32400
+  selector:
+    app: plex
+---
+# Dedicated LB IP for remote access and app direct play (bypasses the gateway).
+apiVersion: v1
+kind: Service
+metadata:
+  name: plex-direct
+  namespace: media
+  annotations:
+    io.cilium/lb-ipam-ips: "10.77.20.226"
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 32400
+      protocol: TCP
+  selector:
+    app: plex

--- a/kubernetes/apps/media/plex/storage.yaml
+++ b/kubernetes/apps/media/plex/storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-data
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/apps/media/seerr/deployment.yaml
+++ b/kubernetes/apps/media/seerr/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seerr
+  namespace: media
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: seerr
+  template:
+    metadata:
+      labels:
+        app: seerr
+    spec:
+      # Image runs as its built-in node user (1000:1000).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: seerr
+          image: ghcr.io/seerr-team/seerr:v3.3.0@sha256:c92d2dc117f62185e7bcb88cd56efd374ea79210eaf433275449e8d5988eb5a8
+          ports:
+            - containerPort: 5055
+          env:
+            - name: TZ
+              value: Australia/Melbourne
+            - name: LOG_LEVEL
+              value: info
+          livenessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: 5055
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: 5055
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: seerr-data

--- a/kubernetes/apps/media/seerr/httproute.yaml
+++ b/kubernetes/apps/media/seerr/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: seerr
+  namespace: media
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - seerr.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: seerr
+          port: 5055

--- a/kubernetes/apps/media/seerr/kustomization.yaml
+++ b/kubernetes/apps/media/seerr/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/media/seerr/replicationsource.yaml
+++ b/kubernetes/apps/media/seerr/replicationsource.yaml
@@ -1,0 +1,52 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: seerr-data-volsync
+  namespace: media
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/seerr-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly config backup to the TrueNAS volsync export. Direct copy is not
+# point-in-time consistent; apps with databases pair this with a dump job.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: seerr-data
+  namespace: media
+spec:
+  sourcePVC: seerr-data
+  trigger:
+    schedule: "55 3 * * *"
+  restic:
+    repository: seerr-data-volsync
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/media/seerr/service.yaml
+++ b/kubernetes/apps/media/seerr/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: seerr
+  namespace: media
+spec:
+  ports:
+    - port: 5055
+  selector:
+    app: seerr

--- a/kubernetes/apps/media/seerr/storage.yaml
+++ b/kubernetes/apps/media/seerr/storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: seerr-data
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/media/tautulli/deployment.yaml
+++ b/kubernetes/apps/media/tautulli/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tautulli
+  namespace: media
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tautulli
+  template:
+    metadata:
+      labels:
+        app: tautulli
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: tautulli
+          image: ghcr.io/linuxserver/tautulli:v2.17.1-ls232@sha256:8e1a0d8104422f646c3e89d9b261b0507dc664bd6764baaea0ff0a5718f83b94
+          ports:
+            - containerPort: 8181
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: Australia/Melbourne
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8181
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 8181
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # LSIO s6 init starts as root and drops to PUID/PGID.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 384Mi
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: tautulli-data

--- a/kubernetes/apps/media/tautulli/httproute.yaml
+++ b/kubernetes/apps/media/tautulli/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tautulli
+  namespace: media
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - tautulli.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: tautulli
+          port: 8181

--- a/kubernetes/apps/media/tautulli/kustomization.yaml
+++ b/kubernetes/apps/media/tautulli/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/media/tautulli/replicationsource.yaml
+++ b/kubernetes/apps/media/tautulli/replicationsource.yaml
@@ -1,0 +1,52 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tautulli-data-volsync
+  namespace: media
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/tautulli-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly config backup to the TrueNAS volsync export. Direct copy is not
+# point-in-time consistent; apps with databases pair this with a dump job.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: tautulli-data
+  namespace: media
+spec:
+  sourcePVC: tautulli-data
+  trigger:
+    schedule: "50 3 * * *"
+  restic:
+    repository: tautulli-data-volsync
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/media/tautulli/service.yaml
+++ b/kubernetes/apps/media/tautulli/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tautulli
+  namespace: media
+spec:
+  ports:
+    - port: 8181
+  selector:
+    app: tautulli

--- a/kubernetes/apps/media/tautulli/storage.yaml
+++ b/kubernetes/apps/media/tautulli/storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tautulli-data
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
## Summary
Stacked on #1546. Adds **plex, tautulli, seerr, kometa, jellyfin** to the media namespace.

- **GPU**: plex + jellyfin request `gpu.intel.com/i915: 1` (shared iGPU via the device plugin) — replaces the compose `/dev/dri` device mounts; no hostPath needed.
- **Transcode**: disk-backed `emptyDir` for both (deliberate change from compose tmpfs — RAM is the scarce resource; commented in the manifests).
- **kometa → CronJob** (`0 5 * * *`, `--run` single pass, Forbid): the k8s schedule replaces its internal scheduler and saves ~512Mi of idle memory.
- **plex-direct**: LoadBalancer `10.77.20.226:32400` for app/remote direct play. `PLEX_CLAIM` via optional ExternalSecret (`plex/claim`).
- jellyfin runs as 1000:1000 with `supplementalGroups: [992]` (render group, replacing compose `group_add`); seerr verified to run as `node` (1000) and gets the full runAsNonRoot context; tautulli keeps its LSIO cap set.
- VolSync ReplicationSources for plex/tautulli/seerr/kometa/jellyfin data PVCs (03:45–04:05); jellyfin-cache deliberately not backed up (rebuildable).

**Note**: jellyfin's compose published 8096 directly on the LAN; in k8s it is gateway-only (`jellyfin.local.elmurphy.com`). If direct-IP LAN access still matters (e.g. client discovery), say so and it gets a LoadBalancer like plex.

## Verification
`kubectl kustomize kubernetes/apps/media | kubeconform` — 90 resources, 90 valid, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)