### PR TITLE
docs(ansible): trim verbose comments

### DIFF
--- a/ansible/group_vars/docker.yaml
+++ b/ansible/group_vars/docker.yaml
@@ -6,8 +6,7 @@ swap_mode: file
 swap_size_gb: 4
 swap_swappiness: 10
 
-# enables DOCKER-USER filtering (see roles/firewall); docker-published ports
-# not listed here are dropped
+# Published Docker ports must be allowlisted in DOCKER-USER.
 firewall_docker_allowed_ports:
   - {port: 80, proto: tcp}  # traefik
   - {port: 443, proto: tcp}  # traefik

--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -1,16 +1,14 @@
 ---
-# OPEN ITEMS to verify on the live router: interface/bridge names, admin + IPMI IPs.
-# Required: create a restricted API user first (creds in vaulted secrets.yaml):
+# Requires a restricted API user (credentials in vaulted secrets.yaml):
 #   /user group add name=ansible policy=api,read,write,policy,test,sensitive
 #   /user add name=ansible group=ansible password=<vaulted>
 routeros_api_host: 10.77.1.1
 
-# Use the ansible-playbook interpreter (this nix shell has librouteros); don't let discovery pick another python.
+# RouterOS modules need the playbook Python, which has librouteros.
 ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
-# L2 topology — verified 2026-06-01 via /ip/neighbor + bridge/host MAC matching.
-# Port map: ether1=WAN, ether2=Proxmox eno1/vmbr1 (DMZ), ether3=Proxmox eno2/vmbr0 (trunk),
-# ether4=UniFi U6-Pro AP, ether5=Proxmox IPMI/BMC (10.77.1.99). ether6/7/8/sfp unused.
+# Port map verified 2026-06-01: ether1 WAN, ether2 DMZ, ether3 trunk,
+# ether4 AP, ether5 IPMI, ether6 fallback, ether7 OOB.
 routeros_bridge: bridge
 routeros_trunk_ports: # tagged production VLANs (native/untagged = MGMT VLAN 1)
   - ether3 # Proxmox eno2 (vmbr0 trunk)
@@ -19,53 +17,42 @@ routeros_mgmt_untagged_ports:
   - ether5 # Proxmox IPMI/BMC — untagged MGMT access (already a bridge member)
 routeros_dmz_port: ether2 # Proxmox eno1 (vmbr1); MUST be removed from the bridge for isolation
 
-# Out-of-band management port: pulled OUT of the bridge with its own /30, so it stays
-# reachable no matter what the bridge / vlan-filtering does. This is the recovery path
-# the 2026-06-03 lockout lacked — under vlan-filtering BOTH untagged-VLAN1 console
-# access AND Winbox-by-MAC die, so a bridge port is not a real fallback. Plug a laptop
-# into this port with a static 10.66.0.2/30 to reach the router at 10.66.0.1.
+# Dedicated recovery port: plug in as 10.66.0.2/30 and reach 10.66.0.1.
 routeros_oob_port: ether7
 routeros_oob_ip: 10.66.0.1/30
 routeros_oob_subnet: 10.66.0.0/30
 
-# Ports carrying untagged native MGMT (VLAN 1) once filtering is on. ether6 is the
-# in-bridge wired fallback (ether7 is now the out-of-band port above).
+# Ports carrying native MGMT (VLAN 1) when filtering is enabled.
 routeros_vlan1_untagged_ports:
   - ether3 # Proxmox trunk (native MGMT)
   - ether4 # UniFi AP trunk (native MGMT)
   - ether5 # IPMI access
   - ether6 # free — wired console fallback
 
-# MGMT = existing flat network (kept as-is, referenced by the firewall).
 routeros_mgmt_subnet: 10.77.1.0/24
 routeros_admin_station: 10.77.1.241 # this Mac (MGMT) — see note: DHCP, reserve a lease before default-drop
 routeros_ipmi_host: 10.77.1.99 # Proxmox IPMI/BMC
 routeros_unifi_ctrl: 10.77.1.10
 routeros_truenas_host: 10.77.20.101
 routeros_docker_host_srv_ip: 10.77.20.246
-# Router management is allowed from the wired MGMT subnet plus the dedicated OOB
-# recovery link. MGMT is intentionally not exposed by a WiFi SSID.
+# Router management is wired MGMT plus OOB only.
 routeros_router_admin_sources:
   - "{{ routeros_mgmt_subnet }}"
   - "{{ routeros_oob_subnet }}" # out-of-band port can always manage the router
 routeros_mgmt_admin_sources: "{{ routeros_router_admin_sources | join(',') }}"
 
-# Wired MGMT is trusted for same-VLAN infrastructure management. It is not a
-# blanket routed bypass into SRV/DFLT/KDS/GST/DMZ; add explicit forward rules
-# only for routed management targets that genuinely need them.
+# Routed management access stays explicit; this is not a blanket bypass.
 routeros_admin_sources:
   - "{{ routeros_mgmt_subnet }}"
 
-# Tagged on the trunk bridge; MGMT/VLAN 1 is the untagged net.
-# SRV pool ends at .223: 10.77.20.224-254 is the Kubernetes LoadBalancer
-# range (Cilium L2), and .20 (static Talos node) sits below the pool.
+# SRV pool avoids the Talos node and Cilium LoadBalancer range.
 routeros_vlans:
   - { id: 20, name: srv, subnet: 10.77.20.0/24, gateway: 10.77.20.1, pool_start: 10.77.20.50, pool_end: 10.77.20.223 }
   - { id: 30, name: dflt, subnet: 10.77.30.0/24, gateway: 10.77.30.1, pool_start: 10.77.30.50, pool_end: 10.77.30.250 }
   - { id: 50, name: kds, subnet: 10.77.50.0/24, gateway: 10.77.50.1, pool_start: 10.77.50.50, pool_end: 10.77.50.250, dns: "{{ routeros_kids_dns }}" }
   - { id: 60, name: gst, subnet: 10.77.60.0/24, gateway: 10.77.60.1, pool_start: 10.77.60.50, pool_end: 10.77.60.250 }
 
-# DMZ — dedicated physical port, no VLAN tag.
+# DMZ is a dedicated physical port, not a VLAN.
 routeros_dmz:
   name: dmz
   subnet: 10.77.99.0/24
@@ -73,8 +60,7 @@ routeros_dmz:
   pool_start: 10.77.99.50
   pool_end: 10.77.99.250
 
-# Named policy objects. Keep these derived from the topology data above so the
-# firewall role reads by intent without duplicating subnet/interface literals.
+# Derived policy objects for the firewall role.
 routeros_vlan_subnets: "{{ routeros_vlans | map(attribute='subnet') | list }}"
 routeros_internal_subnets: "{{ [routeros_mgmt_subnet, routeros_dmz.subnet] + routeros_vlan_subnets }}"
 routeros_lan_input_interfaces: >-
@@ -97,39 +83,25 @@ routeros_wan_egress_subnets: >-
 routeros_default_dns: 10.77.1.1
 routeros_kids_dns: 1.1.1.3 # Cloudflare Families
 
-# Kubernetes objects on SRV. The LB range mirrors the Cilium pool
-# (kubernetes/infrastructure/controllers/cilium/networks.yaml); the node IP is
-# static in talos/controlplane-patch.yaml. LB VIPs are the published surface
-# of the cluster; the node itself is management plane only.
+# Kubernetes addresses on SRV; LB range mirrors Cilium.
 routeros_k8s_node_ip: 10.77.20.20
 routeros_k8s_lb_range: 10.77.20.224-10.77.20.254
 
-# MGMT DHCP reliability. MGMT (native VLAN 1) keeps its server on the raw bridge; we
-# only set a sane lease time and pin infra to fixed addresses so a missed renewal can
-# never strand a critical host. (The recurring DHCP outages were the VLAN-1 binding,
-# fixed in bridge.yaml — not the pool; these are belt-and-suspenders.)
+# MGMT DHCP stays on the raw bridge; pin critical leases for recovery.
 routeros_dhcp_lease_time: 1d
-# Reservations carry device MAC addresses, so MAC variables live in vaulted
-# secrets.yaml. Keep stable device identifiers out of the plaintext repo.
+# Reservation MACs live in vaulted secrets.yaml.
 # Vault entry shape:
 #   routeros_mgmt_reservations:
 #     - { name: proxmox, mac: "<mac>", ip: 10.77.1.10 }
 routeros_mgmt_reservations: []
 
-# Service VLAN reservations. TrueNAS and docker-host intentionally moved off
-# MGMT after the VLAN rollout; keep addresses stable so DNS, NFS exports, and
-# service configs do not depend on the dynamic pool.
+# Stable SRV leases used by DNS, NFS exports and service configs.
 routeros_srv_reservations:
   - { name: truenas, mac: "{{ routeros_truenas_mac }}", ip: "{{ routeros_truenas_host }}" }
   - { name: docker-host, mac: "{{ routeros_docker_host_mac }}", ip: "{{ routeros_docker_host_srv_ip }}" }
 
-# DMZ isolation is safe to keep on (it's a separate physical port, not the bridge).
 routeros_enable_dmz: true
 
-# LOCKOUT-RISK FLIPS — default OFF. A normal `just routeros` run must NEVER enable
-# these (vlan-filtering is also `never`-tagged in bridge.yaml as a second gate).
-# Enable explicitly, ONE at a time, only after: (1) the out-of-band port is up and
-# verified reachable, and (2) MGMT VLAN-1 DHCP is confirmed working. A 2026-06-03
-# apply with these on (MGMT bound to the raw bridge) caused a full lockout — see README.
+# Lockout-risk flips: keep off for normal runs; enable explicitly after OOB is verified.
 routeros_enable_vlan_filtering: false
 routeros_enable_default_drop: false

--- a/ansible/group_vars/unifi.yaml
+++ b/ansible/group_vars/unifi.yaml
@@ -9,11 +9,7 @@ swap_swappiness: 10
 unifi_admin_source: 10.77.1.0/24
 unifi_ap_source: 10.77.1.0/24
 
-# Admin + AP ports are scoped to the MGMT subnet: MGMT is wired-only on VLAN 1, so the
-# controller GUI/SSH must accept any wired MGMT host, not one reserved IP.
-# MongoDB (27117) is deliberately absent: it binds localhost only, never expose it.
-# SSH is explicitly allowed because the controller has no Tailscale; its from_ip differs from
-# the firewall role's deleted bare 22/tcp rule so it survives default-deny.
+# Controller ports are MGMT-only; MongoDB stays localhost-only.
 firewall_allow_ports:
   - { port: "22", proto: tcp, from: "{{ unifi_admin_source }}" } # ssh / ansible
   - { port: "11443", proto: tcp, from: "{{ unifi_admin_source }}" } # UniFi OS Server console

--- a/ansible/roles/ai-dev/files/osc52-copy
+++ b/ansible/roles/ai-dev/files/osc52-copy
@@ -1,8 +1,5 @@
 #!/bin/sh
-# Managed by Ansible — ai-dev role.
-# Read stdin, base64-encode, emit OSC 52 to target tty so the outer
-# terminal (ghostty/wezterm via mosh) writes it to the macOS pasteboard.
-# tmux's copy-pipe spawns without a controlling tty, so the pane tty must
-# be passed as $1 (use #{pane_tty} in tmux bindings).
+# Managed by Ansible: ai-dev role.
+# tmux copy-pipe passes the pane tty as $1.
 tty="${1:-/dev/tty}"
 printf '\033]52;c;%s\a' "$(base64 -w0)" > "$tty"

--- a/ansible/roles/ai-dev/templates/fish/config.fish.j2
+++ b/ansible/roles/ai-dev/templates/fish/config.fish.j2
@@ -1,24 +1,17 @@
-{# Managed by Ansible — ai-dev role. Ported from /home/michael/nixos/modules/home/shell/fish.nix
-   plus the fish-relevant bits of modules/home/shell/cli.nix (eza/fzf/zoxide) and direnv.nix.
-   Palette interpolation pulls from ansible/roles/ai-dev/vars/main.yaml. #}
+{# Managed by Ansible: ai-dev role. #}
 
-# --- PATH ---------------------------------------------------------------------
 # Native Claude Code installer drops launcher at ~/.local/bin/claude but only
-# wires bash/zsh rc files — add it for fish too.
+# wires bash/zsh rc files.
 fish_add_path -g $HOME/.local/bin
 
-# --- Login shell environment --------------------------------------------------
 if status is-login
     set -x BROWSER firefox
 end
 
-# --- Interactive shell only ---------------------------------------------------
 if status is-interactive
-    # Vi keybindings + quiet greeting
     set -g fish_key_bindings fish_vi_key_bindings
     set -g fish_greeting
 
-    # TokyoNight Night fish colors
     set -g fish_color_normal {{ tokyonight.fg }}
     set -g fish_color_command {{ tokyonight.aqua }}
     set -g fish_color_keyword {{ tokyonight.purple }}
@@ -40,10 +33,8 @@ if status is-interactive
     set -g fish_pager_color_description {{ tokyonight.comment }}
     set -g fish_pager_color_selected_background --background={{ tokyonight.bg2 }}
 
-    # TokyoNight LS_COLORS (directories/links emphasized with palette accents)
     set -x LS_COLORS "di=38;2;122;162;247:ln=38;2;125;207;255:so=38;2;187;154;247:pi=38;2;224;175;104:ex=38;2;158;206;106:bd=38;2;255;158;100:cd=38;2;255;158;100:or=38;2;247;118;142:mi=38;2;247;118;142:su=38;2;247;118;142:sg=38;2;224;175;104:tw=38;2;158;206;106:ow=38;2;125;207;255"
 
-    # fzf colors keyed to TokyoNight palette
     set -x FZF_DEFAULT_OPTS "\
 --highlight-line \
 --info=inline-right \
@@ -76,15 +67,10 @@ if status is-interactive
     set -x FZF_CTRL_T_COMMAND "fd --type f --hidden --exclude .git"
     set -x FZF_ALT_C_COMMAND "fd --type d --hidden --exclude .git"
 
-    # --- Aliases / abbreviations ---------------------------------------------
-    # From fish.nix shellAliases
     alias cat='bat'
-
-    # From home.nix shellAliases (ls = "eza -la") + cli.nix programs.eza (icons=auto, --group-directories-first)
     alias ls='eza --icons=auto --group-directories-first -la'
     alias lt='eza --icons=auto --group-directories-first --tree'
 
-    # --- Tool initialisation -------------------------------------------------
     if type -q starship
         starship init fish | source
     end

--- a/ansible/roles/ai-dev/templates/starship.toml.j2
+++ b/ansible/roles/ai-dev/templates/starship.toml.j2
@@ -1,6 +1,4 @@
-# Managed by Ansible — ai-dev role.
-# Ported from /home/michael/nixos/modules/home/shell/starship.nix.
-# Palette interpolation pulls from ansible/roles/ai-dev/vars/main.yaml.
+# Managed by Ansible: ai-dev role.
 
 scan_timeout = 10000
 palette = "tokyonight"

--- a/ansible/roles/ai-dev/templates/tmux.conf.j2
+++ b/ansible/roles/ai-dev/templates/tmux.conf.j2
@@ -1,8 +1,5 @@
-{# Managed by Ansible — ai-dev role.
-   Mirrors leader/keybinds from the prior wezterm.lua so muscle memory carries
-   over. TokyoNight palette interpolated from vars/main.yaml. #}
+{# Managed by Ansible: ai-dev role. #}
 
-# --- Server / general ---------------------------------------------------------
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",xterm-256color:RGB,alacritty:RGB,wezterm:RGB"
 set -g history-limit 50000
@@ -11,36 +8,30 @@ set -g focus-events on
 set -g mouse on
 setw -g mode-keys vi
 
-# OSC 52 clipboard: tmux emits, mosh forwards, ghostty/wezterm write to macOS pasteboard.
+# OSC 52 clipboard through mosh/tmux to the outer terminal.
 set -g set-clipboard on
 set -as terminal-features ',*:clipboard'
 
-# --- Prefix: Ctrl-a (matches old wezterm leader) -----------------------------
 unbind C-b
 set -g prefix C-a
 bind C-a send-prefix
 
-# --- Windows / panes ----------------------------------------------------------
-# Open splits in the current pane's CWD.
 bind '\' split-window -h -c "#{pane_current_path}"
 bind '-' split-window -v -c "#{pane_current_path}"
 bind c   new-window   -c "#{pane_current_path}"
 
-# Window navigation: prefix p/n (default), plus prefix 1..8 (default).
 bind x confirm-before -p "kill pane? (y/n)" kill-pane
 bind z resize-pane -Z
 bind w choose-tree -Zw
 bind , command-prompt -I "#W" "rename-window '%%'"
 bind r switch-client -T resize_pane
 
-# Resize-pane table (LEADER r → h/j/k/l, Escape to exit).
 bind -T resize_pane h resize-pane -L 1 \; switch-client -T resize_pane
 bind -T resize_pane j resize-pane -D 1 \; switch-client -T resize_pane
 bind -T resize_pane k resize-pane -U 1 \; switch-client -T resize_pane
 bind -T resize_pane l resize-pane -R 1 \; switch-client -T resize_pane
 bind -T resize_pane Escape switch-client -T root
 
-# --- smart-splits: Ctrl-h/j/k/l pane navigation, vim-aware -------------------
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
 bind -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
 bind -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
@@ -51,12 +42,10 @@ bind -T copy-mode-vi C-j select-pane -D
 bind -T copy-mode-vi C-k select-pane -U
 bind -T copy-mode-vi C-l select-pane -R
 
-# --- Copy mode (vi) -----------------------------------------------------------
 bind -T copy-mode-vi v   send -X begin-selection
 bind -T copy-mode-vi y   send -X copy-pipe-and-cancel "osc52-copy #{pane_tty}"
 bind -T copy-mode-vi C-v send -X rectangle-toggle
 
-# --- TokyoNight Night theme ---------------------------------------------------
 set -g status-position bottom
 set -g status-justify left
 set -g status-interval 5

--- a/ansible/roles/common/defaults/main.yaml
+++ b/ansible/roles/common/defaults/main.yaml
@@ -4,9 +4,8 @@ swap_mode: file
 swap_size_gb: 4
 swap_swappiness: 60
 
-# zram-generator options (used when swap_mode == zram)
+# Used when swap_mode == zram.
 zram_size: ram
 zram_compression: zstd
 
-# Bound persistent systemd journal growth.
 journald_system_max_use: 500M

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,6 +1,5 @@
 ---
-# this role manages compose stacks but deliberately does not install docker
-# (host runs docker-ce; an apt docker.io install would conflict)
+# Docker is installed outside this role.
 - name: check docker compose availability
   ansible.builtin.command:
     cmd: docker compose version
@@ -114,7 +113,7 @@
     path: "{{ pocket_id_encryption_key_path }}"
   register: pocket_id_key_file
 
-# side-effect free; runs in --check so the key fact below resolves
+# Runs in --check so the key fact below resolves.
 - name: generate Pocket ID encryption key
   ansible.builtin.command:
     cmd: openssl rand -hex 32
@@ -142,7 +141,7 @@
   when: pocket_id_key_file.stat.exists
   no_log: true
 
-# freshly generated key is used directly; in --check the file is never written
+# In --check, use the generated key without writing it.
 - name: set Pocket ID encryption key fact
   ansible.builtin.set_fact:
     pocket_id_encryption_key: >-
@@ -164,7 +163,7 @@
     mode: "0600"
   no_log: true
 
-# no --force-recreate: compose only recreates services whose config/image changed
+# Let compose decide which services need recreation.
 - name: start init compose file
   ansible.builtin.command:
     cmd: docker compose up -d --remove-orphans

--- a/ansible/roles/firewall/handlers/main.yaml
+++ b/ansible/roles/firewall/handlers/main.yaml
@@ -1,6 +1,5 @@
 ---
-# ufw reload re-renders after.rules into the still-loaded DOCKER-USER chain,
-# appending below its terminal RETURN; flush first so edits take effect
+# Flush DOCKER-USER before ufw reload so regenerated rules take effect.
 - name: flush docker-user chain
   ansible.builtin.command: iptables -F DOCKER-USER
   register: docker_user_flush

--- a/ansible/roles/firewall/tasks/main.yaml
+++ b/ansible/roles/firewall/tasks/main.yaml
@@ -34,10 +34,7 @@
   loop: "{{ firewall_allow_ports | default([]) }}"
   notify: reload ufw
 
-# docker-host only: docker's DNAT/FORWARD rules bypass ufw's default-deny, so
-# published ports must be allowlisted in DOCKER-USER instead (ufw-docker
-# pattern, github.com/chaifeng/ufw-docker). after.rules survives reboots and
-# docker restarts; only NEW connections on the external interface are filtered.
+# Docker-published ports bypass ufw default-deny; filter them in DOCKER-USER.
 - name: allowlist docker published ports in DOCKER-USER
   ansible.builtin.blockinfile:
     path: /etc/ufw/after.rules
@@ -58,7 +55,7 @@
     - flush docker-user chain
     - reload ufw
 
-# ssh stays reachable via the tailscale0 allow rule above
+# SSH stays reachable via tailscale0.
 - name: delete bare 22/tcp allow rule
   community.general.ufw:
     rule: allow

--- a/ansible/roles/routeros/tasks/bridge.yaml
+++ b/ansible/roles/routeros/tasks/bridge.yaml
@@ -12,14 +12,7 @@
   loop_control:
     label: "{{ item.name }} ({{ item.id }})"
 
-# VLAN 1 (native MGMT) — untagged ports only, the bridge is NOT a tagged member.
-# The MGMT IP + DHCP stay on the raw `bridge` interface, which reaches VLAN 1 via the
-# bridge PVID (=1) untagged path. Adding the bridge to VLAN 1's *tagged* list (the
-# previous design) is what broke dynamic MGMT DHCP under vlan-filtering: the bridge
-# then expected VLAN 1 *tagged* while the raw-bridge IP/DHCP operate untagged, so
-# untagged clients' DISCOVERs went unanswered (the recurring AP/GL.iNet/docker-host
-# failures). Untagged-only here is MikroTik's native-VLAN-management pattern.
-# ⚠️ Verify from the OOB port that MGMT DHCP still works before enabling filtering.
+# Native MGMT stays untagged; do not add the bridge as a tagged VLAN 1 member.
 - name: VLAN 1 (native MGMT) membership — untagged access ports only (no bridge tag)
   community.routeros.api_modify:
     path: interface bridge vlan
@@ -40,11 +33,7 @@
         pvid: 1
   loop: "{{ routeros_mgmt_untagged_ports }}"
 
-# ⚠️ LOCKOUT RISK. Double-gated: the `routeros_enable_vlan_filtering` var AND the
-# `never` tag, so a normal run can never flip it — you must pass `--tags vlan-filtering`
-# explicitly. Only do so with the out-of-band port verified reachable and MGMT VLAN-1
-# DHCP confirmed working (a 2026-06-03 flip with MGMT on the raw bridge locked everything
-# out, and the in-bridge console fallback died with it).
+# Lockout risk: requires both the var and explicit `--tags vlan-filtering`.
 - name: Enable bridge VLAN filtering (LOCKOUT RISK)
   community.routeros.api_modify:
     path: interface bridge

--- a/ansible/roles/routeros/tasks/dhcp.yaml
+++ b/ansible/roles/routeros/tasks/dhcp.yaml
@@ -36,16 +36,13 @@
   loop_control:
     label: "{{ item.name }}"
 
-# MGMT keeps its existing bridge-bound DHCP server (Fix A leaves the MGMT IP/DHCP on
-# the raw bridge). Codify only what matters for reliability: a sane lease time and
-# static reservations, so a missed renewal can never strand a critical host (the
-# failure that downed docker-host and, most likely, the "bricked" AP).
+# MGMT DHCP stays bridge-bound; only tune lease time and reservations.
 - name: Find the MGMT DHCP server bound to the bridge
   community.routeros.api:
     path: ip dhcp-server
     query: ".id name interface WHERE interface == {{ routeros_bridge }}"
   register: _mgmt_dhcp
-  check_mode: false # read-only query; must run in --check so the set below resolves
+  check_mode: false # query must run in --check so the set below resolves
 
 - name: Set the MGMT DHCP lease time
   community.routeros.api_modify:

--- a/ansible/roles/routeros/tasks/dmz.yaml
+++ b/ansible/roles/routeros/tasks/dmz.yaml
@@ -1,18 +1,16 @@
 ---
-# Isolation requires ether2 off the production bridge before the gateway IP applies; it ships as a defconf member.
-# DISRUPTIVE: de-bridging ether2 drops ai-dev VMs on vmbr1 off MGMT — they re-DHCP into 10.77.99.0/24. Gated (var + tag).
+# Disruptive: de-bridging ether2 moves vmbr1 guests into the DMZ subnet.
 - name: Find the DMZ port's bridge-port entry
   community.routeros.api:
     path: interface bridge port
     query: ".id interface WHERE interface == {{ routeros_dmz_port }}"
   register: _dmz_bridge_port
-  check_mode: false # read-only query; must run even in --check so the loop below resolves
+  check_mode: false # query must run in --check so the loop resolves
 
 - name: Remove the DMZ port from the production bridge (physical isolation)
   community.routeros.api:
     path: interface bridge port
     remove: "{{ item['.id'] }}"
-  # Drop the "no results" string the query returns when already de-bridged, so that case is a no-op.
   loop: "{{ _dmz_bridge_port.msg | select('mapping') | list }}"
   loop_control:
     label: "{{ routeros_dmz_port }}"

--- a/ansible/roles/routeros/tasks/firewall.yaml
+++ b/ansible/roles/routeros/tasks/firewall.yaml
@@ -1,6 +1,5 @@
 ---
-# Managed forward rules are reconciled as one ordered subset; unrelated defconf/WAN rules are left alone.
-# Assumes the default `WAN` interface-list exists.
+# Reconcile managed rules only; leave defconf/WAN rules alone.
 - name: Address-list of all internal subnets ("internal")
   community.routeros.api_modify:
     path: ip firewall address-list
@@ -49,14 +48,7 @@
         comment: "managed: routeros role"
       {% endfor %}
 
-# The defconf input chain ends with `drop chain=input in-interface-list=!LAN`. MGMT
-# rides the bridge, which defconf already put in LAN, so MGMT DHCP/DNS to the router
-# survives. The routed VLAN interfaces, the de-bridged DMZ port and the OOB port are
-# NOT in LAN, so their router-bound traffic would hit that drop (the managed input
-# accepts below get appended AFTER the defconf drop, so they cannot rescue it). Add
-# client VLANs/DMZ for DHCP/DNS and OOB for break-glass router input. Sensitive
-# management services stay source-pinned in services.yaml; OOB routed traffic is
-# explicitly dropped in the forward chain below.
+# Defconf drops non-LAN router input, so routed VLANs/DMZ/OOB must be LAN members.
 - name: Address-lists for the Kubernetes node and LoadBalancer range
   community.routeros.api_modify:
     path: ip firewall address-list
@@ -103,13 +95,7 @@
     handle_absent_entries: ignore
     data: "{{ _routeros_input_policy | from_yaml }}"
   vars:
-    # The router is the DHCP and DNS server for its clients; these inbound services are
-    # permitted explicitly as belt-and-suspenders so they survive future input-chain
-    # tightening. Function today comes from LAN membership above (these accepts append
-    # after the defconf !LAN drop, so they are inert until the chain is reordered).
-    # DHCP DISCOVER comes from 0.0.0.0, so
-    # scope it by ingress interface (not source address) to keep it off the WAN. MGMT
-    # rides the raw bridge (native VLAN 1), the routed VLANs their vlanX interfaces.
+    # DHCP is scoped by ingress interface because DISCOVER starts from 0.0.0.0.
     _routeros_input_policy: |
       {% for interface in routeros_lan_input_interfaces %}
       - chain: input
@@ -196,9 +182,7 @@
         dst-port: 853
         action: drop
         comment: "KDS drop DoQ (managed: routeros role)"
-      # Mirrors the Talos ingress firewall (defense in depth): only MGMT may
-      # reach the node's Kubernetes/Talos APIs, nothing else reaches the node.
-      # Must precede the blanket VLAN -> SRV accepts below.
+      # Keep the Talos node management-only; must precede VLAN -> SRV accepts.
       - chain: forward
         src-address-list: admin
         dst-address-list: k8s-node
@@ -210,8 +194,7 @@
         dst-address-list: k8s-node
         action: drop
         comment: "k8s node mgmt-only drop (managed: routeros role)"
-      # Explicit client -> LB intent; today still shadowed by the blanket
-      # VLAN -> SRV accepts, which go away with the docker-host decommission.
+      # Explicit client -> LB intent; currently shadowed by VLAN -> SRV accepts.
       - chain: forward
         src-address: "{{ _net.dflt }}"
         dst-address-list: k8s-lb

--- a/ansible/roles/routeros/tasks/main.yaml
+++ b/ansible/roles/routeros/tasks/main.yaml
@@ -1,11 +1,9 @@
 ---
-# Lockout-safe ordering matters: membership and allow rules are reconciled before hardening flips.
+# Order matters: reconcile reachability before hardening flips.
 - name: Harden the management plane (disable telnet/cleartext, pin services to MGMT)
   ansible.builtin.import_tasks: services.yaml
   tags: [services]
 
-# Bring up the out-of-band port early so it is available as the safety net before any
-# of the VLAN/bridge work (and well before the gated vlan-filtering flip).
 - name: Out-of-band management port (off the bridge, own /30)
   ansible.builtin.import_tasks: oob.yaml
   tags: [oob]

--- a/ansible/roles/routeros/tasks/oob.yaml
+++ b/ansible/roles/routeros/tasks/oob.yaml
@@ -1,15 +1,11 @@
 ---
-# Out-of-band management port. Removed from the bridge and given its own /30 so it is
-# reachable regardless of bridge / vlan-filtering state — the recovery path the
-# 2026-06-03 lockout lacked. Set up BEFORE any vlan-filtering flip so it can serve as
-# the safety net. The OOB subnet is in routeros_router_admin_sources, so management
-# services accept it. Plug a laptop in with a static 10.66.0.2/30 to reach 10.66.0.1.
+# Set up OOB before any bridge/VLAN hardening so there is a recovery path.
 - name: Find the OOB port's bridge-port entry
   community.routeros.api:
     path: interface bridge port
     query: ".id interface WHERE interface == {{ routeros_oob_port }}"
   register: _oob_bridge_port
-  check_mode: false # read-only query; must run in --check so the loop resolves
+  check_mode: false # query must run in --check so the loop resolves
 
 - name: Remove the OOB port from the bridge (out-of-band isolation)
   community.routeros.api:

--- a/ansible/roles/routeros/tasks/services.yaml
+++ b/ansible/roles/routeros/tasks/services.yaml
@@ -1,5 +1,5 @@
 ---
-# Telnet was being brute-forced from the WAN; disable cleartext/unused services and pin encrypted ones to MGMT.
+# Disable cleartext/unused services and source-pin encrypted management.
 - name: Validate RouterOS management service sources
   ansible.builtin.assert:
     that:
@@ -21,8 +21,7 @@
       - name: api # plain (cleartext) API; we use api-ssl only
         disabled: true
 
-# LOCKOUT NOTE: router management is allowed from the whole wired MGMT subnet (plus the OOB
-# /30), so any wired MGMT DHCP client can manage the router without a pinned reserved IP.
+# Management is allowed from wired MGMT plus OOB.
 - name: Restrict encrypted management services to MGMT
   community.routeros.api_modify:
     path: ip service


### PR DESCRIPTION
## Summary
- Trim verbose and repeated comments across Ansible vars, RouterOS tasks, ai-dev templates, and Docker/firewall roles
- Keep operational notes for lockout risk, OOB recovery, check-mode behavior, and Docker firewall behavior

## Validation
- git diff --cached --check before commit
- comment-only cleanup; no Ansible execution required