### PR TITLE
feat(kubernetes): add tools and auth apps

### DIFF
--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pocket-id

--- a/kubernetes/apps/auth/pocket-id/deployment.yaml
+++ b/kubernetes/apps/auth/pocket-id/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pocket-id
+  namespace: auth
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: pocket-id
+  template:
+    metadata:
+      labels:
+        app: pocket-id
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pocket-id
+          image: ghcr.io/pocket-id/pocket-id:v2.8.0@sha256:a073640418b2cfc8587c488a7270580b3ab95cae2c543f5d64bbbe1fd7ccbae8
+          ports:
+            - containerPort: 1411
+          env:
+            - name: APP_URL
+              value: https://pocket-id.local.elmurphy.com
+            - name: TRUST_PROXY
+              value: "true"
+            - name: ANALYTICS_DISABLED
+              value: "true"
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pocket-id-credentials
+                  key: encryption-key
+            - name: MAXMIND_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pocket-id-credentials
+                  key: maxmind-license-key
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 1411
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 1411
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          resources:
+            requests:
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: pocket-id-data

--- a/kubernetes/apps/auth/pocket-id/httproute.yaml
+++ b/kubernetes/apps/auth/pocket-id/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pocket-id
+  namespace: auth
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - pocket-id.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: pocket-id
+          port: 1411

--- a/kubernetes/apps/auth/pocket-id/kustomization.yaml
+++ b/kubernetes/apps/auth/pocket-id/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/auth/pocket-id/replicationsource.yaml
+++ b/kubernetes/apps/auth/pocket-id/replicationsource.yaml
@@ -1,0 +1,51 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pocket-id-restic
+  namespace: auth
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/pocket-id-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly file backup to the TrueNAS volsync export.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: pocket-id-data
+  namespace: auth
+spec:
+  sourcePVC: pocket-id-data
+  trigger:
+    schedule: "25 4 * * *"
+  restic:
+    repository: pocket-id-restic
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/auth/pocket-id/secret.yaml
+++ b/kubernetes/apps/auth/pocket-id/secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pocket-id-credentials
+  namespace: auth
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+  data:
+    - secretKey: encryption-key
+      remoteRef:
+        key: pocket-id/encryption-key
+    - secretKey: maxmind-license-key
+      remoteRef:
+        key: pocket-id/maxmind-license-key

--- a/kubernetes/apps/auth/pocket-id/service.yaml
+++ b/kubernetes/apps/auth/pocket-id/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pocket-id
+  namespace: auth
+spec:
+  selector:
+    app: pocket-id
+  ports:
+    - name: http
+      port: 1411
+      targetPort: 1411

--- a/kubernetes/apps/auth/pocket-id/storage.yaml
+++ b/kubernetes/apps/auth/pocket-id/storage.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pocket-id-data
+  namespace: auth
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/default/renovate/cronjob.yaml
+++ b/kubernetes/apps/default/renovate/cronjob.yaml
@@ -4,7 +4,6 @@ metadata:
   name: renovate
   namespace: default
 spec:
-  suspend: true
   schedule: "@hourly"
   concurrencyPolicy: Forbid
   jobTemplate:
@@ -13,7 +12,7 @@ spec:
         spec:
           containers:
             - name: renovate
-              image: renovate/renovate:43.220.0@sha256:459b7e28aa54fa2fa7db83df6a2d6ad26de416a054ee554e7833203adf3d9a47
+              image: renovate/renovate:43.218.0@sha256:9f4192ceb275bff402959efc88eb492bb130624080940d495b90789095df1cd9
               args:
                 - mich-murphy/home-infra
               env:

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - default/renovate
   - media
   - immich
+  - tools
+  - auth

--- a/kubernetes/apps/tools/couchdb/configmap.yaml
+++ b/kubernetes/apps/tools/couchdb/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: couchdb-config
+  namespace: tools
+data:
+  cors.ini: |
+    [chttpd]
+    enable_cors = true
+
+    [cors]
+    origins = app://obsidian.md, capacitor://localhost, http://localhost
+    credentials = true
+    headers = accept, authorization, content-type, origin, referer
+    methods = GET, PUT, POST, HEAD, DELETE
+    max_age = 3600

--- a/kubernetes/apps/tools/couchdb/deployment.yaml
+++ b/kubernetes/apps/tools/couchdb/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: couchdb
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: couchdb
+  template:
+    metadata:
+      labels:
+        app: couchdb
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 5984
+        runAsGroup: 5984
+        fsGroup: 5984
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: couchdb
+          image: couchdb:3.5.2@sha256:9a84b943671e9587a690e0c4418e0bd89984b5045db84532add2e560e6b76127
+          ports:
+            - containerPort: 5984
+          env:
+            - name: COUCHDB_USER
+              value: admin
+            - name: COUCHDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: couchdb-credentials
+                  key: password
+          livenessProbe:
+            httpGet:
+              path: /_up
+              port: 5984
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /_up
+              port: 5984
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /opt/couchdb/data
+            - name: config
+              mountPath: /opt/couchdb/etc/local.d/cors.ini
+              subPath: cors.ini
+          resources:
+            requests:
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: couchdb-data
+        - name: config
+          configMap:
+            name: couchdb-config

--- a/kubernetes/apps/tools/couchdb/httproute.yaml
+++ b/kubernetes/apps/tools/couchdb/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: couchdb
+  namespace: tools
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - couchdb.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: couchdb
+          port: 5984

--- a/kubernetes/apps/tools/couchdb/kustomization.yaml
+++ b/kubernetes/apps/tools/couchdb/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - secret.yaml
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml

--- a/kubernetes/apps/tools/couchdb/secret.yaml
+++ b/kubernetes/apps/tools/couchdb/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: couchdb-credentials
+  namespace: tools
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+  data:
+    - secretKey: password
+      remoteRef:
+        key: couchdb/password

--- a/kubernetes/apps/tools/couchdb/service.yaml
+++ b/kubernetes/apps/tools/couchdb/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: couchdb
+  namespace: tools
+spec:
+  selector:
+    app: couchdb
+  ports:
+    - name: http
+      port: 5984
+      targetPort: 5984

--- a/kubernetes/apps/tools/couchdb/storage.yaml
+++ b/kubernetes/apps/tools/couchdb/storage.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: couchdb-data
+  namespace: tools
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - owncloud
+  - miniflux
+  - wallabag
+  - couchdb

--- a/kubernetes/apps/tools/miniflux/cronjob.yaml
+++ b/kubernetes/apps/tools/miniflux/cronjob.yaml
@@ -1,0 +1,53 @@
+# Point-in-time consistent backup; the db PVC is deliberately not
+# volsync'd — restores come from these dumps.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: miniflux-db-backup
+  namespace: tools
+spec:
+  schedule: "40 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: miniflux-db-backup
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: miniflux-db-backup
+              image: postgres:18@sha256:8ff36f3c66371cba71d20ceedccfc3de9669a68737607888c4ef0af93abe8e39
+              command:
+                - sh
+                - -c
+                # %u keeps one dump per weekday, overwritten weekly.
+                - pg_dump -h miniflux-db -U miniflux miniflux | gzip > "/backup/miniflux-$(date +%u).sql.gz"
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: miniflux-credentials
+                      key: db-password
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+              resources:
+                requests:
+                  memory: 128Mi
+                limits:
+                  memory: 256Mi
+          volumes:
+            - name: backup
+              nfs:
+                server: 10.77.20.101
+                path: /mnt/slow/backups/dumps

--- a/kubernetes/apps/tools/miniflux/deployment.yaml
+++ b/kubernetes/apps/tools/miniflux/deployment.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: miniflux
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: miniflux
+  template:
+    metadata:
+      labels:
+        app: miniflux
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: miniflux
+          image: miniflux/miniflux:2.3.1@sha256:42f14382a035e9d9bbc33910ca53f72d47177f75c3c638d2c5a85adf5582d538
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: miniflux-credentials
+                  key: database-url
+            - name: CREATE_ADMIN
+              value: "1"
+            - name: ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: miniflux-credentials
+                  key: admin-username
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: miniflux-credentials
+                  key: admin-password
+            - name: BASE_URL
+              value: https://miniflux.local.elmurphy.com
+            - name: RUN_MIGRATIONS
+              value: "1"
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: miniflux-db
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: miniflux-db
+  template:
+    metadata:
+      labels:
+        app: miniflux-db
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: miniflux-db
+          image: postgres:18@sha256:8ff36f3c66371cba71d20ceedccfc3de9669a68737607888c4ef0af93abe8e39
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: miniflux
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: miniflux-credentials
+                  key: db-password
+            - name: POSTGRES_DB
+              value: miniflux
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - miniflux
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - miniflux
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Entrypoint starts as root and drops to the postgres user.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          volumeMounts:
+            - name: db
+              mountPath: /var/lib/postgresql
+          resources:
+            requests:
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: db
+          persistentVolumeClaim:
+            claimName: miniflux-db

--- a/kubernetes/apps/tools/miniflux/httproute.yaml
+++ b/kubernetes/apps/tools/miniflux/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: miniflux
+  namespace: tools
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - miniflux.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: miniflux
+          port: 8080

--- a/kubernetes/apps/tools/miniflux/kustomization.yaml
+++ b/kubernetes/apps/tools/miniflux/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - networkpolicy.yaml
+  - cronjob.yaml

--- a/kubernetes/apps/tools/miniflux/networkpolicy.yaml
+++ b/kubernetes/apps/tools/miniflux/networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: miniflux-db
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app: miniflux-db
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: miniflux
+        - matchLabels:
+            app: miniflux-db-backup
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/tools/miniflux/secret.yaml
+++ b/kubernetes/apps/tools/miniflux/secret.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: miniflux-credentials
+  namespace: tools
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        db-password: "{{ .dbPassword }}"
+        admin-username: "{{ .adminUsername }}"
+        admin-password: "{{ .adminPassword }}"
+        database-url: postgres://miniflux:{{ .dbPassword }}@miniflux-db/miniflux?sslmode=disable
+  data:
+    - secretKey: dbPassword
+      remoteRef:
+        key: miniflux/db-password
+    - secretKey: adminUsername
+      remoteRef:
+        key: miniflux/admin-username
+    - secretKey: adminPassword
+      remoteRef:
+        key: miniflux/admin-password

--- a/kubernetes/apps/tools/miniflux/service.yaml
+++ b/kubernetes/apps/tools/miniflux/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: miniflux
+  namespace: tools
+spec:
+  ports:
+    - port: 8080
+  selector:
+    app: miniflux
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: miniflux-db
+  namespace: tools
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: miniflux-db

--- a/kubernetes/apps/tools/miniflux/storage.yaml
+++ b/kubernetes/apps/tools/miniflux/storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: miniflux-db
+  namespace: tools
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/tools/owncloud/cronjob.yaml
+++ b/kubernetes/apps/tools/owncloud/cronjob.yaml
@@ -1,0 +1,53 @@
+# Point-in-time consistent backup; the db PVC is deliberately not
+# volsync'd — restores come from these dumps.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: owncloud-db-backup
+  namespace: tools
+spec:
+  schedule: "35 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: owncloud-db-backup
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: owncloud-db-backup
+              image: mariadb:12.3.2@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b
+              command:
+                - sh
+                - -c
+                # %u keeps one dump per weekday, overwritten weekly.
+                - mariadb-dump -h owncloud-mariadb -u root --all-databases | gzip > "/backup/owncloud-$(date +%u).sql.gz"
+              env:
+                - name: MYSQL_PWD
+                  valueFrom:
+                    secretKeyRef:
+                      name: owncloud-credentials
+                      key: db-password
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+              resources:
+                requests:
+                  memory: 128Mi
+                limits:
+                  memory: 256Mi
+          volumes:
+            - name: backup
+              nfs:
+                server: 10.77.20.101
+                path: /mnt/slow/backups/dumps

--- a/kubernetes/apps/tools/owncloud/deployment.yaml
+++ b/kubernetes/apps/tools/owncloud/deployment.yaml
@@ -1,0 +1,265 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: owncloud
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: owncloud
+  template:
+    metadata:
+      labels:
+        app: owncloud
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: owncloud
+          image: owncloud/server:10.16.3@sha256:e05d1d12b61073c1e7f80ddab6eb015cbbf7bed1d409fa270cc94662bd8693a7
+          ports:
+            - containerPort: 8080
+          env:
+            - name: OWNCLOUD_DOMAIN
+              value: owncloud.local.elmurphy.com
+            - name: OWNCLOUD_TRUSTED_DOMAINS
+              value: owncloud.local.elmurphy.com
+            - name: OWNCLOUD_DB_TYPE
+              value: mysql
+            - name: OWNCLOUD_DB_NAME
+              value: owncloud
+            - name: OWNCLOUD_DB_USERNAME
+              value: owncloud
+            - name: OWNCLOUD_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: owncloud-credentials
+                  key: db-password
+            - name: OWNCLOUD_DB_HOST
+              value: owncloud-mariadb
+            - name: OWNCLOUD_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: owncloud-credentials
+                  key: admin-username
+            - name: OWNCLOUD_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: owncloud-credentials
+                  key: admin-password
+            - name: OWNCLOUD_MYSQL_UTF8MB4
+              value: "true"
+            - name: OWNCLOUD_REDIS_ENABLED
+              value: "true"
+            - name: OWNCLOUD_REDIS_HOST
+              value: owncloud-redis
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/healthcheck
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/healthcheck
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Entrypoint starts as root and drops to www-data.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          volumeMounts:
+            - name: data
+              mountPath: /mnt/data
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: owncloud-data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: owncloud-mariadb
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: owncloud-mariadb
+  template:
+    metadata:
+      labels:
+        app: owncloud-mariadb
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: owncloud-mariadb
+          image: mariadb:12.3.2@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b # minimum required ownCloud version is 10.9
+          args:
+            - --max-allowed-packet=128M
+            - --innodb-log-file-size=64M
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: owncloud-credentials
+                  key: db-password
+            - name: MYSQL_USER
+              value: owncloud
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: owncloud-credentials
+                  key: db-password
+            - name: MYSQL_DATABASE
+              value: owncloud
+            - name: MARIADB_AUTO_UPGRADE
+              value: "1"
+          livenessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+                - --connect
+                - --innodb_initialized
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+                - --connect
+                - --innodb_initialized
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Entrypoint starts as root and drops to the mysql user.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          volumeMounts:
+            - name: db
+              mountPath: /var/lib/mysql
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: db
+          persistentVolumeClaim:
+            claimName: owncloud-db
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: owncloud-redis
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: owncloud-redis
+  template:
+    metadata:
+      labels:
+        app: owncloud-redis
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: owncloud-redis
+          image: redis:8.8.0@sha256:aa049e689e141a4358ad1d4562dc49c88a89fbab711fd8fcc33f684c80b26301
+          args:
+            - --databases
+            - "1"
+          ports:
+            - containerPort: 6379
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Entrypoint starts as root and drops to the redis user;
+              # SETPCAP lets it shed its own capabilities afterwards.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+                - SETPCAP
+          volumeMounts:
+            - name: cache
+              mountPath: /data
+          resources:
+            requests:
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      volumes:
+        # Cache only; nothing worth persisting.
+        - name: cache
+          emptyDir: {}

--- a/kubernetes/apps/tools/owncloud/httproute.yaml
+++ b/kubernetes/apps/tools/owncloud/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: owncloud
+  namespace: tools
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - owncloud.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: owncloud
+          port: 8080

--- a/kubernetes/apps/tools/owncloud/kustomization.yaml
+++ b/kubernetes/apps/tools/owncloud/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - networkpolicy.yaml
+  - cronjob.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/tools/owncloud/networkpolicy.yaml
+++ b/kubernetes/apps/tools/owncloud/networkpolicy.yaml
@@ -1,0 +1,37 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: owncloud-mariadb
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app: owncloud-mariadb
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: owncloud
+        - matchLabels:
+            app: owncloud-db-backup
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: owncloud-redis
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app: owncloud-redis
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: owncloud
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP

--- a/kubernetes/apps/tools/owncloud/replicationsource.yaml
+++ b/kubernetes/apps/tools/owncloud/replicationsource.yaml
@@ -1,0 +1,48 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: owncloud-data-volsync
+  namespace: tools
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/owncloud-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly file backup to the TrueNAS volsync export. Direct copy is not
+# point-in-time consistent; the database pairs this with a dump job.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: owncloud-data
+  namespace: tools
+spec:
+  sourcePVC: owncloud-data
+  trigger:
+    schedule: "10 4 * * *"
+  restic:
+    repository: owncloud-data-volsync
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/tools/owncloud/secret.yaml
+++ b/kubernetes/apps/tools/owncloud/secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: owncloud-credentials
+  namespace: tools
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+  data:
+    - secretKey: db-password
+      remoteRef:
+        key: owncloud/db-password
+    - secretKey: admin-username
+      remoteRef:
+        key: owncloud/admin-username
+    - secretKey: admin-password
+      remoteRef:
+        key: owncloud/admin-password

--- a/kubernetes/apps/tools/owncloud/service.yaml
+++ b/kubernetes/apps/tools/owncloud/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: owncloud
+  namespace: tools
+spec:
+  ports:
+    - port: 8080
+  selector:
+    app: owncloud
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: owncloud-mariadb
+  namespace: tools
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: owncloud-mariadb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: owncloud-redis
+  namespace: tools
+spec:
+  ports:
+    - port: 6379
+  selector:
+    app: owncloud-redis

--- a/kubernetes/apps/tools/owncloud/storage.yaml
+++ b/kubernetes/apps/tools/owncloud/storage.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: owncloud-data
+  namespace: tools
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: owncloud-db
+  namespace: tools
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/tools/wallabag/cronjob.yaml
+++ b/kubernetes/apps/tools/wallabag/cronjob.yaml
@@ -1,0 +1,53 @@
+# Point-in-time consistent backup; the db PVC is deliberately not
+# volsync'd — restores come from these dumps.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: wallabag-db-backup
+  namespace: tools
+spec:
+  schedule: "45 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: wallabag-db-backup
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: wallabag-db-backup
+              image: mariadb:12.3.2@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b
+              command:
+                - sh
+                - -c
+                # %u keeps one dump per weekday, overwritten weekly.
+                - mariadb-dump -h wallabag-db -u root --all-databases | gzip > "/backup/wallabag-$(date +%u).sql.gz"
+              env:
+                - name: MYSQL_PWD
+                  valueFrom:
+                    secretKeyRef:
+                      name: wallabag-credentials
+                      key: db-password
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+              resources:
+                requests:
+                  memory: 128Mi
+                limits:
+                  memory: 256Mi
+          volumes:
+            - name: backup
+              nfs:
+                server: 10.77.20.101
+                path: /mnt/slow/backups/dumps

--- a/kubernetes/apps/tools/wallabag/deployment.yaml
+++ b/kubernetes/apps/tools/wallabag/deployment.yaml
@@ -1,0 +1,236 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wallabag
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: wallabag
+  template:
+    metadata:
+      labels:
+        app: wallabag
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wallabag
+          image: wallabag/wallabag:2.6.14@sha256:4a527e027e0d59e87c14225ef11e005af3d4890374202ad319ce5e63dfc66709
+          ports:
+            - containerPort: 80
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wallabag-credentials
+                  key: db-password
+            - name: SYMFONY__ENV__DATABASE_DRIVER
+              value: pdo_mysql
+            - name: SYMFONY__ENV__DATABASE_HOST
+              value: wallabag-db
+            - name: SYMFONY__ENV__DATABASE_PORT
+              value: "3306"
+            - name: SYMFONY__ENV__DATABASE_NAME
+              value: wallabag
+            - name: SYMFONY__ENV__DATABASE_USER
+              value: wallabag
+            - name: SYMFONY__ENV__DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wallabag-credentials
+                  key: db-password
+            - name: SYMFONY__ENV__DATABASE_CHARSET
+              value: utf8mb4
+            - name: SYMFONY__ENV__DOMAIN_NAME
+              value: https://wallabag.local.elmurphy.com
+            - name: SYMFONY__ENV__SERVER_NAME
+              value: '"Wallabag"'
+            # Image default is the bare hostname "redis"; point at the service.
+            - name: SYMFONY__ENV__REDIS_HOST
+              value: wallabag-redis
+          livenessProbe:
+            httpGet:
+              path: /api/info
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/info
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Entrypoint starts as root, drops to nobody, and binds port 80.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+                - NET_BIND_SERVICE
+          volumeMounts:
+            - name: data
+              mountPath: /var/www/wallabag/web/assets/images
+          resources:
+            requests:
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: wallabag-data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wallabag-db
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: wallabag-db
+  template:
+    metadata:
+      labels:
+        app: wallabag-db
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wallabag-db
+          image: mariadb:12.3.2@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wallabag-credentials
+                  key: db-password
+          livenessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+                - --connect
+                - --innodb_initialized
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+                - --connect
+                - --innodb_initialized
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Entrypoint starts as root and drops to the mysql user.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          volumeMounts:
+            - name: db
+              mountPath: /var/lib/mysql
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: db
+          persistentVolumeClaim:
+            claimName: wallabag-db
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wallabag-redis
+  namespace: tools
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: wallabag-redis
+  template:
+    metadata:
+      labels:
+        app: wallabag-redis
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wallabag-redis
+          image: redis:8.8.0-alpine@sha256:09160599abd229764c0fb44cb6be640294e1d360a54b19985ab4843dcf2d90f1
+          ports:
+            - containerPort: 6379
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # Entrypoint starts as root and drops to the redis user.
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - FOWNER
+                - KILL
+          resources:
+            requests:
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/apps/tools/wallabag/httproute.yaml
+++ b/kubernetes/apps/tools/wallabag/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wallabag
+  namespace: tools
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - wallabag.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: wallabag
+          port: 80

--- a/kubernetes/apps/tools/wallabag/kustomization.yaml
+++ b/kubernetes/apps/tools/wallabag/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - storage.yaml
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml
+  - networkpolicy.yaml
+  - cronjob.yaml
+  - replicationsource.yaml

--- a/kubernetes/apps/tools/wallabag/networkpolicy.yaml
+++ b/kubernetes/apps/tools/wallabag/networkpolicy.yaml
@@ -1,0 +1,37 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: wallabag-db
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app: wallabag-db
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: wallabag
+        - matchLabels:
+            app: wallabag-db-backup
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: wallabag-redis
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app: wallabag-redis
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: wallabag
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP

--- a/kubernetes/apps/tools/wallabag/replicationsource.yaml
+++ b/kubernetes/apps/tools/wallabag/replicationsource.yaml
@@ -1,0 +1,48 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: wallabag-data-volsync
+  namespace: tools
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      data:
+        RESTIC_REPOSITORY: /mnt/repository/wallabag-data
+        RESTIC_PASSWORD: "{{ .resticPassword }}"
+  data:
+    - secretKey: resticPassword
+      remoteRef:
+        key: volsync/restic-password
+---
+# Nightly image-assets backup to the TrueNAS volsync export. Direct copy is
+# not point-in-time consistent; the database pairs this with a dump job.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: wallabag-data
+  namespace: tools
+spec:
+  sourcePVC: wallabag-data
+  trigger:
+    schedule: "15 4 * * *"
+  restic:
+    repository: wallabag-data-volsync
+    copyMethod: Direct
+    pruneIntervalDays: 14
+    retain:
+      daily: 7
+      weekly: 4
+    cacheCapacity: 2Gi
+    moverVolumes:
+      - name: repository
+        mountPath: repository
+        volumeSource:
+          nfs:
+            server: 10.77.20.101
+            path: /mnt/slow/backups/volsync

--- a/kubernetes/apps/tools/wallabag/secret.yaml
+++ b/kubernetes/apps/tools/wallabag/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: wallabag-credentials
+  namespace: tools
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secrets
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+  data:
+    - secretKey: db-password
+      remoteRef:
+        key: wallabag/db-password

--- a/kubernetes/apps/tools/wallabag/service.yaml
+++ b/kubernetes/apps/tools/wallabag/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wallabag
+  namespace: tools
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: wallabag
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wallabag-db
+  namespace: tools
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: wallabag-db
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wallabag-redis
+  namespace: tools
+spec:
+  ports:
+    - port: 6379
+  selector:
+    app: wallabag-redis

--- a/kubernetes/apps/tools/wallabag/storage.yaml
+++ b/kubernetes/apps/tools/wallabag/storage.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wallabag-data
+  namespace: tools
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wallabag-db
+  namespace: tools
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
## Summary
- add Miniflux, OwnCloud, Wallabag, CouchDB, and Pocket ID Kubernetes manifests
- wire tools/auth into the apps kustomization
- unsuspend the Kubernetes Renovate CronJob

## Validation
- kubectl kustomize kubernetes/apps
- kubeconform apps: 162 valid, 0 invalid, 0 errors