### PR TITLE
feat(kubernetes): add victoria metrics monitoring

### DIFF
--- a/kubernetes/infrastructure/controllers/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - cert-manager
   - external-secrets
   - intel-device-plugins
+  - monitoring
   - openebs
   - volsync

--- a/kubernetes/infrastructure/controllers/monitoring/httproute.yaml
+++ b/kubernetes/infrastructure/controllers/monitoring/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  parentRefs:
+    - name: prod
+      namespace: gateway
+  hostnames:
+    - grafana.local.elmurphy.com
+  rules:
+    - backendRefs:
+        - name: victoria-metrics-k8s-stack-grafana
+          port: 80

--- a/kubernetes/infrastructure/controllers/monitoring/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml
+  - httproute.yaml

--- a/kubernetes/infrastructure/controllers/monitoring/namespace.yaml
+++ b/kubernetes/infrastructure/controllers/monitoring/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/kubernetes/infrastructure/controllers/monitoring/release.yaml
+++ b/kubernetes/infrastructure/controllers/monitoring/release.yaml
@@ -1,0 +1,83 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-metrics-k8s-stack
+  namespace: monitoring
+spec:
+  releaseName: victoria-metrics-k8s-stack
+  interval: 12h
+  chart:
+    spec:
+      chart: victoria-metrics-k8s-stack
+      version: "0.82.0"
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: victoriametrics
+        namespace: monitoring
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled
+  values:
+    victoria-metrics-operator:
+      crds:
+        cleanup:
+          enabled: true
+      operator:
+        disable_prometheus_converter: true
+    vmsingle:
+      enabled: true
+      spec:
+        retentionPeriod: 14d
+        resources:
+          requests:
+            memory: 256Mi
+          limits:
+            memory: 768Mi
+        storage:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 20Gi
+    vmagent:
+      spec:
+        resources:
+          requests:
+            memory: 128Mi
+          limits:
+            memory: 256Mi
+    vmalert:
+      spec:
+        resources:
+          requests:
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+    alertmanager:
+      spec:
+        resources:
+          requests:
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+    grafana:
+      resources:
+        requests:
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+    kubeControllerManager:
+      enabled: false
+    kubeEtcd:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubeProxy:
+      enabled: false

--- a/kubernetes/infrastructure/controllers/monitoring/repository.yaml
+++ b/kubernetes/infrastructure/controllers/monitoring/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: victoriametrics
+  namespace: monitoring
+spec:
+  interval: 24h
+  url: https://victoriametrics.github.io/helm-charts

--- a/kubernetes/infrastructure/crds/kustomization.yaml
+++ b/kubernetes/infrastructure/crds/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   # Standard channel, the version supported by Cilium 1.18. The experimental
   # channel (TLSRoute, ExternalAuth filter) waits for Cilium 1.20.
   - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+  - victoria-metrics-operator-crds-repository.yaml
+  - victoria-metrics-operator-crds-release.yaml

--- a/kubernetes/infrastructure/crds/victoria-metrics-operator-crds-release.yaml
+++ b/kubernetes/infrastructure/crds/victoria-metrics-operator-crds-release.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-metrics-operator-crds
+  namespace: flux-system
+spec:
+  releaseName: victoria-metrics-operator-crds
+  interval: 12h
+  chart:
+    spec:
+      chart: victoria-metrics-operator-crds
+      version: "0.10.1"
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: victoriametrics
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled

--- a/kubernetes/infrastructure/crds/victoria-metrics-operator-crds-repository.yaml
+++ b/kubernetes/infrastructure/crds/victoria-metrics-operator-crds-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: victoriametrics
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://victoriametrics.github.io/helm-charts


### PR DESCRIPTION
## Summary
- add prometheus-operator and VictoriaMetrics operator CRD HelmReleases
- add victoria-metrics-k8s-stack 0.82.0 with Grafana route
- disable control-plane scrape jobs that are not served by single-node Talos

## Validation
- kubectl kustomize kubernetes/infrastructure/controllers
- kubectl kustomize kubernetes/infrastructure/crds
- kubeconform controllers: 22 valid, 0 invalid, 0 errors
- kubeconform CRDs: 4 valid, 0 invalid, 0 errors, 5 skipped