### PR TITLE
feat(kubernetes): migrate wallabag to postgres

### DIFF
--- a/docs/k8s-migration.md
+++ b/docs/k8s-migration.md
@@ -28,6 +28,44 @@ Terraform is run with `-var enable_talos=true`.
 | qBittorrent peers | `10.77.20.225` | WAN dst-nat target after cutover |
 | Plex direct | `10.77.20.226` | Direct LoadBalancer service |
 
+## Database Direction
+
+Kubernetes SQL workloads should use PostgreSQL where the application supports
+it well and upstream guidance does not argue against it. Current coverage:
+
+| App | Docker source | Kubernetes target | Restore artifact |
+| --- | --- | --- | --- |
+| Immich | PostgreSQL | PostgreSQL | `pg_dumpall` |
+| Miniflux | PostgreSQL | PostgreSQL | `pg_dump` |
+| OwnCloud | MariaDB | MariaDB | `mariadb-dump` |
+| Wallabag | MariaDB | PostgreSQL | converted PostgreSQL dump |
+
+Use app-scoped database instances for this migration instead of a shared
+CloudNativePG cluster. For PostgreSQL workloads, the repo is already structured
+around app-scoped Deployments, Services, NetworkPolicies, and dump CronJobs; on
+a single-node Talos cluster, a shared PostgreSQL operator adds another
+controller and a larger shared failure domain before it adds useful HA. A later
+hardening pass can replace the app-scoped PostgreSQL Deployments with
+CloudNativePG `Cluster` resources, preferably one cluster per high-value app
+rather than one shared cluster for everything. A single shared PostgreSQL
+cluster is operationally tidy, but it couples app maintenance, PostgreSQL
+major-version timing, extension needs, and restore blast radius.
+
+Exception: ownCloud supports PostgreSQL, but the upstream ownCloud Server system
+requirements officially recommend MariaDB for best performance, stability,
+support, and full functionality. Keep OwnCloud on MariaDB to follow the
+vendor-recommended path and reduce migration risk.
+
+CloudNativePG is still the likely future direction once the migration has
+soaked. It provides declarative PostgreSQL clusters, managed services for
+application connections, declarative database resources, WAL/base backups,
+PITR-capable recovery, and PostgreSQL-native import paths. References:
+
+- <https://cloudnative-pg.io/docs/1.29/>
+- <https://cloudnative-pg.io/docs/1.29/declarative_database_management/>
+- <https://cloudnative-pg.io/docs/1.29/backup/>
+- <https://cloudnative-pg.io/docs/1.29/recovery/>
+
 ## Preflight
 
 1. Populate the 1Password `kubernetes` vault:
@@ -35,7 +73,7 @@ Terraform is run with `-var enable_talos=true`.
    - `qbitwebui/encryption-key`
    - `plex/claim`, if a fresh claim is needed
    - `immich/db-password`
-   - `owncloud/admin-password`, `owncloud/db-root-password`, `owncloud/db-password`
+   - `owncloud/admin-password`, `owncloud/db-password`
    - `miniflux/admin-username`, `miniflux/admin-password`, `miniflux/db-password`
    - `wallabag/db-password`
    - `couchdb/password`
@@ -59,16 +97,104 @@ Terraform is run with `-var enable_talos=true`.
 7. Rehearse database dumps from docker-host:
    - `pg_dumpall` for Immich PostgreSQL
    - `pg_dump` for Miniflux PostgreSQL
-   - `mariadb-dump` for OwnCloud and Wallabag
+   - `mariadb-dump` for OwnCloud MariaDB
+   - `mariadb-dump` source backup and PostgreSQL conversion dump for Wallabag
+8. Rehearse file-volume tars from docker-host for every named volume. Database
+   PVCs restore from SQL dumps, not volume tars.
+
+## Backup Artifacts
+
+Create one cutover directory on the TrueNAS dumps export and keep both raw
+source backups and Kubernetes-ready restore artifacts:
+
+```sh
+stamp="$(date +%Y%m%d-%H%M%S)"
+backup_root="/mnt/slow/backups/dumps/cutover-${stamp}"
+sudo install -d -m 0700 "${backup_root}/raw" "${backup_root}/postgres" "${backup_root}/volumes"
+sudo install -d -m 0700 "${backup_root}/mariadb"
+```
+
+Required SQL artifacts:
+
+| File | Purpose |
+| --- | --- |
+| `raw/immich.sql.gz` | Raw Docker-host PostgreSQL dump for rollback/debug |
+| `postgres/immich.sql.gz` | Kubernetes restore dump |
+| `raw/miniflux.sql.gz` | Raw Docker-host PostgreSQL dump for rollback/debug |
+| `postgres/miniflux.sql.gz` | Kubernetes restore dump |
+| `mariadb/owncloud.sql.gz` | Kubernetes OwnCloud MariaDB restore dump |
+| `raw/wallabag-mariadb.sql.gz` | Raw Docker-host MariaDB backup |
+| `postgres/wallabag.sql.gz` | Converted PostgreSQL restore dump |
+
+For Immich and Miniflux, the raw and restore dumps can be the same PostgreSQL
+dump copied into both locations:
+
+```sh
+docker compose -f docker/immich/compose.yml exec -T database \
+  sh -c 'pg_dumpall -U "$POSTGRES_USER"' \
+  | gzip | sudo tee "${backup_root}/postgres/immich.sql.gz" >/dev/null
+sudo cp "${backup_root}/postgres/immich.sql.gz" "${backup_root}/raw/immich.sql.gz"
+
+docker compose -f docker/miniflux/compose.yml exec -T miniflux-db \
+  sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' \
+  | gzip | sudo tee "${backup_root}/postgres/miniflux.sql.gz" >/dev/null
+sudo cp "${backup_root}/postgres/miniflux.sql.gz" "${backup_root}/raw/miniflux.sql.gz"
+```
+
+For OwnCloud, keep the MariaDB dump as the Kubernetes restore artifact:
+
+```sh
+docker compose -f docker/owncloud/compose.yml exec -T owncloud-mariadb \
+  sh -c 'mariadb-dump -u root -p"$MYSQL_ROOT_PASSWORD" --single-transaction --routines --triggers --events --all-databases' \
+  | gzip | sudo tee "${backup_root}/mariadb/owncloud.sql.gz" >/dev/null
+```
+
+For Wallabag, take a raw MariaDB dump first:
+
+```sh
+docker compose -f docker/wallabag/compose.yml exec -T db \
+  sh -c 'mariadb-dump -u root -p"$MYSQL_ROOT_PASSWORD" --single-transaction --routines --triggers --events --all-databases' \
+  | gzip | sudo tee "${backup_root}/raw/wallabag-mariadb.sql.gz" >/dev/null
+```
+
+Then produce PostgreSQL-ready dumps before the Terraform flip. The exact
+conversion command should be rehearsed against disposable Docker volumes:
+
+- Wallabag: use a temporary PostgreSQL container and an app/schema-aware
+  conversion path such as `pgloader` from the live MariaDB container, then
+  `pg_dump -U wallabag wallabag` to `postgres/wallabag.sql.gz`.
+
+Do not treat the Wallabag MariaDB SQL dump as directly restorable into
+PostgreSQL.
 
 ## Freeze and Backup
 
 1. Stop Portainer GitOps or otherwise prevent compose redeploys.
-2. Stop application stacks with Docker Compose.
-3. Run final database dumps to the TrueNAS staging area.
-4. Tar each named Docker volume from
+2. Run final database dumps and the Wallabag PostgreSQL conversion dump to the
+   TrueNAS staging area.
+3. Stop application stacks with Docker Compose.
+4. Tar each non-database named Docker volume from
    `/var/lib/docker/volumes/<name>/_data` to a TrueNAS staging directory.
 5. Keep docker-host disks intact. They are the first rollback path.
+
+Useful volume tar pattern:
+
+```sh
+for volume in \
+  audiobookshelf-data audiobookshelf-metadata beszel-data couchdb-data \
+  immich-ml-cache jellyfin-cache jellyfin-data kometa-data lidarr-data \
+  owncloud-cache owncloud-data pinchflat-data plex-data plex-transcode \
+  pocketid-data portainer-data prowlarr-data qbittorrent-data qbitwebui-data \
+  radarr-data sabnzbd-data seerr-data sonarr-data tautulli-data traefik-data \
+  wallabag-data
+do
+  sudo tar -C "/var/lib/docker/volumes/${volume}/_data" \
+    -czf "${backup_root}/volumes/${volume}.tgz" .
+done
+```
+
+Skip database volumes when restoring to Kubernetes. Keep their raw tars only
+for forensic rollback if you deliberately add them to the list.
 
 ## Terraform Flip
 
@@ -156,6 +282,36 @@ For each stateful app:
 
 Database PVCs are restored from dumps, not VolSync direct copies. Direct
 filesystem copies of live databases are not point-in-time safe.
+
+Database restore examples:
+
+```sh
+# Immich
+kubectl -n immich scale deploy/immich-server --replicas=0
+gunzip -c "${backup_root}/postgres/immich.sql.gz" \
+  | kubectl -n immich exec -i deploy/postgres -- sh -c \
+    'psql -U "$POSTGRES_USER" postgres'
+kubectl -n immich scale deploy/immich-server --replicas=1
+
+# Miniflux
+kubectl -n tools scale deploy/miniflux --replicas=0
+gunzip -c "${backup_root}/postgres/miniflux.sql.gz" \
+  | kubectl -n tools exec -i deploy/miniflux-db -- psql -U miniflux miniflux
+kubectl -n tools scale deploy/miniflux --replicas=1
+
+# OwnCloud
+kubectl -n tools scale deploy/owncloud --replicas=0
+gunzip -c "${backup_root}/mariadb/owncloud.sql.gz" \
+  | kubectl -n tools exec -i deploy/owncloud-mariadb -- sh -c \
+    'mariadb -u root -p"$MYSQL_ROOT_PASSWORD"'
+kubectl -n tools scale deploy/owncloud --replicas=1
+
+# Wallabag
+kubectl -n tools scale deploy/wallabag --replicas=0
+gunzip -c "${backup_root}/postgres/wallabag.sql.gz" \
+  | kubectl -n tools exec -i deploy/wallabag-db -- psql -U wallabag wallabag
+kubectl -n tools scale deploy/wallabag --replicas=1
+```
 
 ## DNS and Network Cutover
 

--- a/kubernetes/apps/tools/wallabag/cronjob.yaml
+++ b/kubernetes/apps/tools/wallabag/cronjob.yaml
@@ -21,14 +21,14 @@ spec:
               type: RuntimeDefault
           containers:
             - name: wallabag-db-backup
-              image: mariadb:12.3.2@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b
+              image: postgres:18@sha256:8ff36f3c66371cba71d20ceedccfc3de9669a68737607888c4ef0af93abe8e39
               command:
                 - sh
                 - -c
                 # %u keeps one dump per weekday, overwritten weekly.
-                - mariadb-dump -h wallabag-db -u root --all-databases | gzip > "/backup/wallabag-$(date +%u).sql.gz"
+                - pg_dump -h wallabag-db -U wallabag wallabag | gzip > "/backup/wallabag-$(date +%u).sql.gz"
               env:
-                - name: MYSQL_PWD
+                - name: PGPASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: wallabag-credentials

--- a/kubernetes/apps/tools/wallabag/deployment.yaml
+++ b/kubernetes/apps/tools/wallabag/deployment.yaml
@@ -24,17 +24,12 @@ spec:
           ports:
             - containerPort: 80
           env:
-            - name: MYSQL_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: wallabag-credentials
-                  key: db-password
             - name: SYMFONY__ENV__DATABASE_DRIVER
-              value: pdo_mysql
+              value: pdo_pgsql
             - name: SYMFONY__ENV__DATABASE_HOST
               value: wallabag-db
             - name: SYMFONY__ENV__DATABASE_PORT
-              value: "3306"
+              value: "5432"
             - name: SYMFONY__ENV__DATABASE_NAME
               value: wallabag
             - name: SYMFONY__ENV__DATABASE_USER
@@ -45,7 +40,7 @@ spec:
                   name: wallabag-credentials
                   key: db-password
             - name: SYMFONY__ENV__DATABASE_CHARSET
-              value: utf8mb4
+              value: utf8
             - name: SYMFONY__ENV__DOMAIN_NAME
               value: https://wallabag.local.elmurphy.com
             - name: SYMFONY__ENV__SERVER_NAME
@@ -118,21 +113,25 @@ spec:
           type: RuntimeDefault
       containers:
         - name: wallabag-db
-          image: mariadb:12.3.2@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b
+          image: postgres:18@sha256:8ff36f3c66371cba71d20ceedccfc3de9669a68737607888c4ef0af93abe8e39
           ports:
-            - containerPort: 3306
+            - containerPort: 5432
           env:
-            - name: MYSQL_ROOT_PASSWORD
+            - name: POSTGRES_USER
+              value: wallabag
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: wallabag-credentials
                   key: db-password
+            - name: POSTGRES_DB
+              value: wallabag
           livenessProbe:
             exec:
               command:
-                - healthcheck.sh
-                - --connect
-                - --innodb_initialized
+                - pg_isready
+                - -U
+                - wallabag
             initialDelaySeconds: 30
             periodSeconds: 20
             timeoutSeconds: 3
@@ -140,9 +139,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - healthcheck.sh
-                - --connect
-                - --innodb_initialized
+                - pg_isready
+                - -U
+                - wallabag
             initialDelaySeconds: 5
             periodSeconds: 20
             timeoutSeconds: 3
@@ -152,7 +151,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-              # Entrypoint starts as root and drops to the mysql user.
+              # Entrypoint starts as root and drops to the postgres user.
               add:
                 - CHOWN
                 - SETUID
@@ -162,7 +161,7 @@ spec:
                 - KILL
           volumeMounts:
             - name: db
-              mountPath: /var/lib/mysql
+              mountPath: /var/lib/postgresql
           resources:
             requests:
               memory: 256Mi

--- a/kubernetes/apps/tools/wallabag/networkpolicy.yaml
+++ b/kubernetes/apps/tools/wallabag/networkpolicy.yaml
@@ -15,7 +15,7 @@ spec:
             app: wallabag-db-backup
       toPorts:
         - ports:
-            - port: "3306"
+            - port: "5432"
               protocol: TCP
 ---
 apiVersion: cilium.io/v2

--- a/kubernetes/apps/tools/wallabag/service.yaml
+++ b/kubernetes/apps/tools/wallabag/service.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: tools
 spec:
   ports:
-    - port: 3306
+    - port: 5432
   selector:
     app: wallabag-db
 ---


### PR DESCRIPTION
## Summary
- migrate Wallabag's Kubernetes database sidecar from MariaDB to PostgreSQL
- update Wallabag database service, network policy, and dump CronJob for PostgreSQL
- document the Docker-host backup and Kubernetes restore flow, keeping OwnCloud on MariaDB per upstream recommendation

## Validation
- kubectl kustomize kubernetes/apps
- git diff --check