### PR TITLE
fix(firewall): allow Docker bridge to reach Tailscale services

### DIFF
--- a/ansible/group_vars/docker.yaml
+++ b/ansible/group_vars/docker.yaml
@@ -6,6 +6,10 @@ swap_mode: file
 swap_size_gb: 4
 swap_swappiness: 10
 
+# Allows containers on the compose proxy bridge to reach services via
+# *.local.elmurphy.com, which currently resolves to Tailscale.
+firewall_docker_bridge_subnet: 172.20.1.0/24
+
 # Published Docker ports must be allowlisted in DOCKER-USER.
 firewall_docker_allowed_ports:
   - {port: 80, proto: tcp}  # traefik

--- a/ansible/roles/firewall/tasks/main.yaml
+++ b/ansible/roles/firewall/tasks/main.yaml
@@ -55,6 +55,16 @@
     - flush docker-user chain
     - reload ufw
 
+# docker-host only: lets containers reach services whose names resolve to
+# Tailscale addresses, such as *.local.elmurphy.com.
+- name: allow internal docker bridge to tailscale
+  community.general.ufw:
+    rule: allow
+    from_ip: "{{ firewall_docker_bridge_subnet }}"
+    to_ip: 100.64.0.0/10
+  when: firewall_docker_bridge_subnet is defined
+  notify: reload ufw
+
 # SSH stays reachable via tailscale0.
 - name: delete bare 22/tcp allow rule
   community.general.ufw:


### PR DESCRIPTION
## Summary
- restore the Docker bridge to Tailscale allow rule for containers using *.local.elmurphy.com service URLs
- keep Docker published-port filtering in DOCKER-USER unchanged

## Verification
- applied equivalent live UFW allow on docker-host
- verified Sonarr -> https://prowlarr.local.elmurphy.com/ping returns 200
- verified Radarr -> https://qbittorrent.local.elmurphy.com returns 200
- ansible-playbook run.yaml --vault-password-file .vaultpass --syntax-check --limit docker --tags firewall