### PR TITLE
Fix guest VLAN and qBittorrent forwarding

### DIFF
--- a/ansible/group_vars/routeros.yaml
+++ b/ansible/group_vars/routeros.yaml
@@ -35,6 +35,11 @@ routeros_ipmi_host: 10.77.1.99 # Proxmox IPMI/BMC
 routeros_unifi_ctrl: 10.77.1.10
 routeros_truenas_host: 10.77.20.101
 routeros_docker_host_srv_ip: 10.77.20.246
+routeros_qbittorrent_peer_port: 25565
+routeros_qbittorrent_peer_target: "{{ routeros_docker_host_srv_ip }}"
+routeros_qbittorrent_peer_protocols:
+  - tcp
+  - udp
 # Router management is wired MGMT plus OOB only.
 routeros_router_admin_sources:
   - "{{ routeros_mgmt_subnet }}"

--- a/ansible/roles/routeros/tasks/firewall.yaml
+++ b/ansible/roles/routeros/tasks/firewall.yaml
@@ -170,6 +170,16 @@
         src-address: "{{ routeros_oob_subnet }}"
         action: drop
         comment: "OOB drop routed traffic (managed: routeros role)"
+      {% for protocol in routeros_qbittorrent_peer_protocols %}
+      - chain: forward
+        in-interface-list: WAN
+        connection-nat-state: dstnat
+        dst-address: "{{ routeros_qbittorrent_peer_target }}"
+        protocol: "{{ protocol }}"
+        dst-port: "{{ routeros_qbittorrent_peer_port }}"
+        action: accept
+        comment: "WAN -> qBittorrent peers {{ protocol }} (managed: routeros role)"
+      {% endfor %}
       - chain: forward
         src-address: "{{ _net.kds }}"
         protocol: tcp
@@ -225,6 +235,11 @@
         action: accept
         comment: "SRV -> UniFi controller (managed: routeros role)"
       - chain: forward
+        src-address: "{{ _net.gst }}"
+        dst-address-list: internal
+        action: drop
+        comment: "GST drop internal routing (managed: routeros role)"
+      - chain: forward
         src-address-list: admin
         out-interface-list: WAN
         action: accept
@@ -265,6 +280,31 @@
         action: redirect
         to-ports: 53
         comment: "KDS TCP DNS redirect (managed: routeros role)"
+
+- name: WAN dst-nat — qBittorrent peer traffic to docker-host
+  community.routeros.api_modify:
+    path: ip firewall nat
+    handle_absent_entries: remove
+    handle_entries_content: remove_as_much_as_possible
+    restrict:
+      - field: chain
+        values:
+          - dstnat
+      - field: comment
+        regex: ".*qBittorrent peers.*managed: routeros role.*"
+    data: "{{ _routeros_qbittorrent_dstnat | from_yaml }}"
+  vars:
+    _routeros_qbittorrent_dstnat: |
+      {% for protocol in routeros_qbittorrent_peer_protocols %}
+      - chain: dstnat
+        in-interface-list: WAN
+        protocol: "{{ protocol }}"
+        dst-port: "{{ routeros_qbittorrent_peer_port }}"
+        action: dst-nat
+        to-addresses: "{{ routeros_qbittorrent_peer_target }}"
+        to-ports: "{{ routeros_qbittorrent_peer_port }}"
+        comment: "WAN -> qBittorrent peers {{ protocol }} (managed: routeros role)"
+      {% endfor %}
 
 - name: Masquerade all internal sources out the WAN
   community.routeros.api_modify:
@@ -308,6 +348,8 @@
           "fwd est/rel (managed: routeros role)",
           "fwd drop invalid (managed: routeros role)",
           "OOB drop routed traffic (managed: routeros role)",
+          "WAN -> qBittorrent peers tcp (managed: routeros role)",
+          "WAN -> qBittorrent peers udp (managed: routeros role)",
           "KDS drop DoT (managed: routeros role)",
           "KDS drop DoQ (managed: routeros role)",
           "MGMT -> k8s node API (managed: routeros role)",
@@ -317,6 +359,7 @@
           "DFLT -> SRV services (managed: routeros role)",
           "KDS -> SRV (Plex/Jellyfin) (managed: routeros role)",
           "SRV -> UniFi controller (managed: routeros role)",
+          "GST drop internal routing (managed: routeros role)",
           "MGMT admins -> WAN (managed: routeros role)"
         ]
         + (routeros_wan_egress_subnets | map('regex_replace', '$', ' -> WAN (managed: routeros role)') | list)

--- a/ansible/roles/routeros/tasks/verify.yaml
+++ b/ansible/roles/routeros/tasks/verify.yaml
@@ -42,6 +42,13 @@
   register: _routeros_verify_forward_filter
   check_mode: false
 
+- name: Verify dst-nat rules
+  community.routeros.api:
+    path: ip firewall nat
+    query: ".id chain action comment protocol dst-port to-addresses to-ports WHERE chain == dstnat"
+  register: _routeros_verify_dstnat
+  check_mode: false
+
 - name: Verify DHCP servers
   community.routeros.api:
     path: ip dhcp-server
@@ -128,6 +135,48 @@
       - "routeros_enable_default_drop | bool or 'DEFAULT DROP (managed: routeros role)' not in _managed_forward_comments"
     fail_msg: Managed forward default-drop state does not match routeros_enable_default_drop.
   vars:
+    _managed_forward_comments: >-
+      {{
+        _routeros_verify_forward_filter.msg
+        | select('mapping')
+        | selectattr('comment', 'defined')
+        | selectattr('comment', 'search', 'managed: routeros role')
+        | map(attribute='comment')
+        | list
+      }}
+
+- name: Assert qBittorrent peer dst-nat rules exist
+  ansible.builtin.assert:
+    that:
+      - "_expected_qbittorrent_dstnat_comments | difference(_managed_dstnat_comments) | length == 0"
+    fail_msg: "Missing qBittorrent dst-nat rules: {{ _expected_qbittorrent_dstnat_comments | difference(_managed_dstnat_comments) }}"
+  vars:
+    _expected_qbittorrent_dstnat_comments: "{{ _expected_qbittorrent_dstnat_comments_yaml | from_yaml }}"
+    _expected_qbittorrent_dstnat_comments_yaml: |
+      {% for protocol in routeros_qbittorrent_peer_protocols %}
+      - "WAN -> qBittorrent peers {{ protocol }} (managed: routeros role)"
+      {% endfor %}
+    _managed_dstnat_comments: >-
+      {{
+        _routeros_verify_dstnat.msg
+        | select('mapping')
+        | selectattr('comment', 'defined')
+        | selectattr('comment', 'search', 'qBittorrent peers.*managed: routeros role')
+        | map(attribute='comment')
+        | list
+      }}
+
+- name: Assert guest isolation and qBittorrent forward rules exist
+  ansible.builtin.assert:
+    that:
+      - "_expected_forward_comments | difference(_managed_forward_comments) | length == 0"
+    fail_msg: "Missing managed forward rules: {{ _expected_forward_comments | difference(_managed_forward_comments) }}"
+  vars:
+    _expected_forward_comments: "{{ (_expected_qbittorrent_forward_comments_yaml | from_yaml) + ['GST drop internal routing (managed: routeros role)'] }}"
+    _expected_qbittorrent_forward_comments_yaml: |
+      {% for protocol in routeros_qbittorrent_peer_protocols %}
+      - "WAN -> qBittorrent peers {{ protocol }} (managed: routeros role)"
+      {% endfor %}
     _managed_forward_comments: >-
       {{
         _routeros_verify_forward_filter.msg

--- a/terraform/network/unifi.tf
+++ b/terraform/network/unifi.tf
@@ -79,7 +79,7 @@ resource "unifi_wlan" "kds" {
   user_group_id = data.unifi_client_qos_rate.default.id
 }
 
-# GST — WPA3 transition + L2 isolation.
+# GST — WPA3 transition on a plain VLAN; RouterOS enforces guest routing policy.
 resource "unifi_wlan" "gst" {
   name            = "madviLANy-gst"
   security        = "wpapsk"
@@ -102,7 +102,7 @@ resource "unifi_wlan" "gst" {
     policy  = "allow"
   }
 
-  is_guest      = true
+  is_guest      = false
   l2_isolation  = true
   network_id    = unifi_network.vlan["gst"].id
   ap_group_ids  = [data.unifi_ap_group.default.id]


### PR DESCRIPTION
## Summary
- make madviLANy-gst a plain VLAN SSID while keeping L2 isolation
- enforce GST internal isolation in RouterOS before WAN egress
- add RouterOS dst-nat and forward rules for qBittorrent peers on 25565/tcp and 25565/udp to docker-host
- verify qBittorrent dst-nat and GST forwarding policy in the RouterOS role

## Validation
- ansible-playbook run.yaml --syntax-check --vault-password-file .vaultpass --limit routeros
- terraform validate
- terraform apply -parallelism=1 -auto-approve
- ansible-playbook run.yaml --vault-password-file .vaultpass --limit routeros --tags services,oob,vlans,dmz,dhcp,firewall,bridge,vlan-filtering,default-drop,verify -e routeros_enable_vlan_filtering=true -e routeros_enable_default_drop=true
- terraform plan -detailed-exitcode