### PR TITLE
Authenticate Renovate GHCR lookups

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -26,6 +26,8 @@ jobs:
         uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
         env:
           RENOVATE_FORCE: ${{ inputs.overrideSchedule == true && '{''schedule'':null}' || '' }}
+          RENOVATE_HOST_RULES: >-
+            [{"hostType":"docker","matchHost":"ghcr.io","username":"mich-murphy","password":"${{ secrets.RENOVATE_TOKEN }}"}]
         with:
           configurationFile: .github/renovate-config.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary
- keep Immich server and machine-learning updates enabled
- authenticate Renovate's Docker lookups against ghcr.io using the existing RENOVATE_TOKEN secret
- avoid anonymous GHCR lookup failures being surfaced on unrelated Renovate PRs

## Findings
- current open Renovate PRs are sabnzbd #1581 and tautulli #1582; both have passing checks
- the PR warning is global, not caused by those packages
- latest Renovate run reports: Failed to look up docker package ghcr.io/immich-app/immich-server: no-result
- direct GHCR manifest checks for the pinned Immich server and machine-learning tags resolve successfully
- local Renovate dry-runs with Immich enabled resolve Immich when registry access succeeds, so the workflow should avoid unauthenticated GHCR access from hosted runners

## Validation
- jq empty renovate.json
- actionlint .github/workflows/renovate.yaml
- docker run --rm -v "/Users/mm/dev/home-infra:/repo" -w /repo ghcr.io/renovatebot/renovate:43.220.0 renovate-config-validator --strict
- docker run --rm -e LOG_LEVEL=info -e RENOVATE_PLATFORM=local -v "/Users/mm/dev/home-infra:/repo" -w /repo ghcr.io/renovatebot/renovate:43.233.3 renovate --dry-run=lookup