### PR TITLE
Fix Jellyfin transcode tmpfs permissions

### DIFF
--- a/docker/jellyfin/compose.yml
+++ b/docker/jellyfin/compose.yml
@@ -38,7 +38,7 @@ services:
         bind:
           propagation: rslave
     tmpfs:
-      - /transcode # ram transcode
+      - /transcode:rw,nosuid,nodev,noexec,uid=1000,gid=1000,mode=1777 # ram transcode
     ports:
       # deliberate direct LAN access; allowlisted in firewall_docker_allowed_ports
       - 8096:8096


### PR DESCRIPTION
## Summary
- make Jellyfin's /transcode tmpfs writable by the non-root 1000:1000 container user
- keep the tmpfs RAM-backed with nosuid/nodev/noexec options

## Validation
- docker compose -f docker/jellyfin/compose.yml config