### PR TITLE
Fix Portainer Pocket ID OAuth routing

### DIFF
--- a/docker/init/compose.yml
+++ b/docker/init/compose.yml
@@ -7,6 +7,10 @@ services:
       - no-new-privileges:true
     networks:
       - proxy
+    extra_hosts:
+      # Portainer performs OAuth token exchange server-side; keep that traffic
+      # inside the proxy network instead of the Tailscale-resolved address.
+      - pocket-id.local.elmurphy.com:172.20.1.13
     volumes:
       - portainer-data:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## Summary
- make Portainer resolve pocket-id.local.elmurphy.com to Traefik on the Docker proxy network for server-side OAuth token exchange
- avoid routing Portainer's OIDC token request to the Tailscale-resolved address that containers cannot reach

## Diagnosis
- Portainer UI shell and assets return 200 through Traefik
- Portainer logs show OAuth token exchange failures to https://pocket-id.local.elmurphy.com/api/oidc/token
- From Portainer's network namespace, pocket-id.local.elmurphy.com resolves to 100.96.174.126 and times out
- Direct Docker-network access to Pocket ID works, and routing the public hostname to Traefik's proxy-network IP succeeds

## Validation
- docker compose -f docker/init/compose.yml config
- disposable container in Portainer network namespace can reach Pocket ID when resolving pocket-id.local.elmurphy.com to Traefik's proxy IP