### PR TITLE
Cap Jellyfin transcode tmpfs size

### DIFF
--- a/docker/jellyfin/compose.yml
+++ b/docker/jellyfin/compose.yml
@@ -38,7 +38,7 @@ services:
         bind:
           propagation: rslave
     tmpfs:
-      - /transcode:rw,nosuid,nodev,noexec,uid=1000,gid=1000,mode=1777 # ram transcode
+      - /transcode:rw,nosuid,nodev,noexec,uid=1000,gid=1000,mode=1777,size=2g # ram transcode
     ports:
       # deliberate direct LAN access; allowlisted in firewall_docker_allowed_ports
       - 8096:8096


### PR DESCRIPTION
## Summary
- cap Jellyfin's RAM-backed /transcode tmpfs at 2 GiB
- keep existing non-root ownership and mount hardening options

## Notes
- discovery/DLNA publishing is intentionally unchanged
- official Jellyfin docs confirm QSV is preferred on mainstream Intel GPUs and LP encoding is supported after LP-mode verification; no config change for low-power encoding is included here

## Validation
- docker compose -f docker/jellyfin/compose.yml config