### PR TITLE
fix(immich): configure machine learning URL

### DIFF
--- a/docker/immich/compose.yml
+++ b/docker/immich/compose.yml
@@ -12,6 +12,8 @@ services:
     networks:
       - proxy
       - immich-backend
+    environment:
+      - IMMICH_MACHINE_LEARNING_URL=http://immich-ml:3003
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
## Summary

- configure Immich Server to use the existing immich-ml Compose service
- restore server-to-ML connectivity after the v3 upgrade

## Validation

- docker compose config --quiet
- confirmed the rendered server environment contains IMMICH_MACHINE_LEARNING_URL=http://immich-ml:3003