### PR TITLE
fix(immich): allow ML model downloads

### DIFF
--- a/docker/immich/compose.yml
+++ b/docker/immich/compose.yml
@@ -38,6 +38,7 @@ services:
       - no-new-privileges:true
     networks:
       - immich-backend
+      - immich-ml-egress
     volumes:
       - immich-ml-cache:/cache
     restart: unless-stopped
@@ -96,6 +97,8 @@ volumes:
 networks:
   proxy:
     external: true
+  immich-ml-egress:
+    name: immich-ml-egress
   immich-backend:
     name: immich-backend
     internal: true


### PR DESCRIPTION
## Summary

- attach Immich ML to a dedicated outbound bridge network
- retain the internal backend network for server-to-ML traffic
- allow Hugging Face model downloads without joining ML to the shared proxy network

## Validation

- docker compose config --quiet
- confirmed immich-ml is attached to both networks
- confirmed immich-backend remains internal and immich-ml-egress is non-internal